### PR TITLE
fix(docs): correct license from MIT to Apache-2.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,4 +135,4 @@ uv run pytest tests/ --cov=anneal    # With coverage
 
 ## License
 
-MIT
+Apache-2.0


### PR DESCRIPTION
## Summary

- The `LICENSE` file at the repository root contains the full **Apache License 2.0** text, which is the project's actual license
- The `README.md` License section incorrectly stated **MIT**, creating a mismatch that could confuse contributors and downstream users
- This PR corrects the README to declare **Apache-2.0**, aligning documentation with the authoritative `LICENSE` file

## Why this matters

License mismatches between README and LICENSE files create legal ambiguity. Users relying on the README would assume MIT terms (no patent grant, minimal conditions), while the actual license is Apache 2.0 (explicit patent grant, NOTICE file preservation requirements). Correcting this removes that ambiguity.

## Changes

| File | Change |
|------|--------|
| `README.md` | `MIT` → `Apache-2.0` in the License section (line 138) |

## Test plan

- [x] Verify `LICENSE` file contains Apache License 2.0 text
- [x] Verify `README.md` now reads `Apache-2.0` under the License heading
- [ ] Confirm no other files reference MIT as the project license