### PR TITLE
fix(build): add Python version classifiers for PyPI badge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,14 @@ version = "0.3.0"
 description = "Domain-agnostic autonomous optimization framework"
 readme = "README.md"
 requires-python = ">=3.12"
+license = "Apache-2.0"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+]
 dependencies = [
     "numpy>=2.0",
     "scipy>=1.14",


### PR DESCRIPTION
## Summary

- Add `Programming Language :: Python :: 3.12`, `3.13`, license, and OS classifiers to `pyproject.toml`
- Fixes the `python missing` shields.io badge in the README

The `pypi/pyversions` badge requires these classifiers in the package metadata. Takes effect on the next PyPI publish.

## Test plan

- [ ] `uv sync --dev` succeeds
- [ ] After next PyPI release, badge at `img.shields.io/pypi/pyversions/anneal-cli` shows `3.12 | 3.13`