### PR TITLE
fix(build): remove redundant license classifier for PEP 639 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
 dependencies = [


### PR DESCRIPTION
## Summary

- Remove `License :: OSI Approved :: Apache Software License` classifier that conflicts with PEP 639 `license = "Apache-2.0"` expression
- Setuptools >= 75 rejects the combination, breaking `uv build`

## Test plan

- [x] `uv build` succeeds
- [x] Built wheel contains `License-Expression: Apache-2.0` in METADATA