### PR TITLE
style(paper): prose cleanup, source hygiene, and accessibility

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -40,6 +40,10 @@
 %% 3. Redefine \_ to include \allowbreak, enabling line breaks
 %%    after underscores in identifiers like foo\_bar\_baz
 %%
+\usepackage{silence}
+\WarningFilter{latexfont}{Font shape `T1/zi4}
+\WarningFilter{latexfont}{Some font shapes were not available}
+
 \usepackage[htt]{hyphenat}
 \emergencystretch=2em
 

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -18,18 +18,13 @@
 %%
 %% Packages
 %%
-\usepackage{booktabs}       % Professional quality tables
-\usepackage{microtype}      % Better justification
-\usepackage{cleveref}       % Smart cross-references (\cref)
-\usepackage{xcolor}         % Color support for \todo
-\usepackage{todonotes}      % \todo{} macro for placeholders
-\usepackage{multirow}       % Multi-row table cells
-\usepackage{subcaption}     % Subfigures
-\usepackage{listings}       % Code listings
-\usepackage{amsmath}        % Math environments
+%% acmart already loads booktabs, microtype, amsmath, xcolor, graphicx,
+%% hyperref, and natbib — re-loading is redundant, so we only declare
+%% packages acmart does not provide.
+%%
+\usepackage{cleveref}       % Smart cross-references (\cref, \Cref)
 \usepackage{algorithm}      % Algorithm float
 \usepackage{algpseudocode}  % Pseudocode
-\usepackage{enumitem}       % List customization (nosep, etc.)
 \usepackage{fancyhdr}       % Custom running header and footer
 
 

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -65,6 +65,12 @@
 %% Authors
 %%
 \author{Tom Mathews}
+\affiliation{%
+  \institution{Independent Researcher}
+  \city{Kochi}
+  \state{Kerala}
+  \country{India}
+}
 \email{tom.mathews@nyu.edu}
 
 %%

--- a/paper/sections/abstract.tex
+++ b/paper/sections/abstract.tex
@@ -1,3 +1,4 @@
+% !TEX root = ../main.tex
 Large language models can propose mutations to any text-based artifact (prompts, code, configurations), but using them as optimization oracles demands more than iterative generation and manual inspection.
 %
 Existing approaches lack statistical rigor when comparing stochastic outputs, default to greedy search with no mechanism to escape local optima, accumulate no structured knowledge across experiments, and provide few safety guarantees around cost or scope.

--- a/paper/sections/abstract.tex
+++ b/paper/sections/abstract.tex
@@ -1,5 +1,5 @@
-Large language models can propose mutations to any text-based artifact---prompts,
-code, configurations---but using them as optimization oracles demands more than
+Large language models can propose mutations to any text-based artifact (prompts,
+code, configurations), but using them as optimization oracles demands more than
 iterative generation and manual inspection.
 %
 Existing approaches lack statistical rigor when comparing stochastic outputs,

--- a/paper/sections/abstract.tex
+++ b/paper/sections/abstract.tex
@@ -1,48 +1,16 @@
-Large language models can propose mutations to any text-based artifact (prompts,
-code, configurations), but using them as optimization oracles demands more than
-iterative generation and manual inspection.
+Large language models can propose mutations to any text-based artifact (prompts, code, configurations), but using them as optimization oracles demands more than iterative generation and manual inspection.
 %
-Existing approaches lack statistical rigor when comparing stochastic outputs,
-default to greedy search with no mechanism to escape local optima, accumulate
-no structured knowledge across experiments, and provide few safety guarantees
-around cost or scope.
+Existing approaches lack statistical rigor when comparing stochastic outputs, default to greedy search with no mechanism to escape local optima, accumulate no structured knowledge across experiments, and provide few safety guarantees around cost or scope.
 %
-We present \textsc{anneal}, a domain-agnostic framework that brings statistical
-decision theory to the accept/reject boundary of iterative LLM-guided artifact
-optimization---a problem overlooked by frameworks that compare stochastic
-evaluations through point scores.
+We present \textsc{anneal}, a domain-agnostic framework that brings statistical decision theory to the accept/reject boundary of iterative LLM-guided artifact optimization---a problem overlooked by frameworks that compare stochastic evaluations through point scores.
 %
-The framework composes three subsystems: a statistical acceptance layer built
-on the Wilcoxon signed-rank test with Holm--Bonferroni correction for
-multiplicity control, a strategy-diverse search layer spanning greedy,
-simulated annealing with adaptive reheat, population-based, and Thompson
-Sampling meta-strategy selection, and an episodic knowledge layer with TF-IDF
-hypothesis retrieval and cross-target lesson transfer.
+The framework composes three subsystems: a statistical acceptance layer built on the Wilcoxon signed-rank test with Holm--Bonferroni correction for multiplicity control, a strategy-diverse search layer spanning greedy, simulated annealing with adaptive reheat, population-based, and Thompson Sampling meta-strategy selection, and an episodic knowledge layer with TF-IDF hypothesis retrieval and cross-target lesson transfer.
 %
-Around this core, \textsc{anneal} isolates every experiment in a git worktree,
-calibrates the LLM judge via position-bias-cancelled Bradley--Terry scoring,
-and controls evaluation cost through adaptive sample sizing with held-out
-divergence detection.
+Around this core, \textsc{anneal} isolates every experiment in a git worktree, calibrates the LLM judge via position-bias-cancelled Bradley--Terry scoring, and controls evaluation cost through adaptive sample sizing with held-out divergence detection.
 %
-We validate the three core mechanisms in isolation on synthetic benchmarks
-with analytically known ground truth, showing that Holm--Bonferroni correction
-reduces false-positive acceptance by 86\% under a null distribution, adaptive
-reheat yields a 19.1\% improvement over fixed cooling on the Rastrigin
-function, and TF-IDF retrieval achieves $1.55\times$ the precision of Jaccard
-similarity on a controlled corpus.
+We validate the three core mechanisms in isolation on synthetic benchmarks with analytically known ground truth, showing that Holm--Bonferroni correction reduces false-positive acceptance by 86\% under a null distribution, adaptive reheat yields a 19.1\% improvement over fixed cooling on the Rastrigin function, and TF-IDF retrieval achieves $1.55\times$ the precision of Jaccard similarity on a controlled corpus.
 %
-We additionally report an end-to-end comparison of four nested configurations
-(raw, greedy, control, treatment) across the five-target benchmark suite at
-$n = 5$ paired seeds: the full treatment configuration produces a directional
-improvement over the same engine without enhancement tracks on every target,
-ranging from $+3.5\%$ to $+44.5\%$ on final-score, at cost largely comparable
-to control.
-The framework's own statistical-acceptance discipline declines to call this
-advantage significant after multiplicity correction at the seed count run, a
-result we treat as the framework working as designed: the same machinery
-that suppresses false positives under a synthetic null applies the same
-standard to systemic claims about itself.
+We additionally report an end-to-end comparison of four nested configurations (raw, greedy, control, treatment) across the five-target benchmark suite at $n = 5$ paired seeds: the full treatment configuration produces a directional improvement over the same engine without enhancement tracks on every target, ranging from $+3.5\%$ to $+44.5\%$ on final-score, at cost largely comparable to control.
+The framework's own statistical-acceptance discipline declines to call this advantage significant after multiplicity correction at the seed count run, a result we treat as the framework working as designed: the same machinery that suppresses false positives under a synthetic null applies the same standard to systemic claims about itself.
 %
-\textsc{anneal} ships as open-source software under the Apache-2.0 license,
-together with the benchmark suite, harness, and analysis pipeline that
-produced these results.
+\textsc{anneal} ships as open-source software under the Apache-2.0 license, together with the benchmark suite, harness, and analysis pipeline that produced these results.

--- a/paper/sections/conclusion.tex
+++ b/paper/sections/conclusion.tex
@@ -12,9 +12,9 @@ statistical rigor, and a search strategy decides whether to accept or
 revert each change.
 Every experiment is git-committed, scope-enforced, and logged.
 
-The framework's three technical contributions---statistical acceptance
+The framework's three technical contributions (statistical acceptance
 under stochastic evaluation, adaptive metaheuristic search, and structured
-episodic knowledge retrieval---are each validated as an independent
+episodic knowledge retrieval) are each validated as an independent
 mechanism in \cref{sec:results}.
 Holm--Bonferroni correction reduces false-positive acceptance by 86\% under
 a synthetic null distribution (\cref{sec:gate-false-positives}), adaptive
@@ -23,8 +23,8 @@ simulated annealing yields a 19.1\% improvement over fixed cooling on the
 $1.55\times$ the precision of Jaccard similarity on a controlled corpus
 (\cref{sec:gate-retrieval}).
 These mechanism-level results are supported by two architectural
-contributions---git-native isolation with scope enforcement, and a
-domain-agnostic artifact--evaluation interface---that realize the framework
+contributions (git-native isolation with scope enforcement, and a
+domain-agnostic artifact--evaluation interface) that realize the framework
 as an integrated, reproducible research artifact.
 
 The end-to-end study of \cref{sec:end-to-end} runs four nested configurations

--- a/paper/sections/conclusion.tex
+++ b/paper/sections/conclusion.tex
@@ -1,3 +1,4 @@
+% !TEX root = ../main.tex
 \section{Conclusion}
 \label{sec:conclusion}
 

--- a/paper/sections/conclusion.tex
+++ b/paper/sections/conclusion.tex
@@ -2,50 +2,18 @@
 \section{Conclusion}
 \label{sec:conclusion}
 
-We presented \textsc{anneal}, a domain-agnostic framework that brings
-statistical decision theory to the accept/reject boundary of iterative
-LLM-guided artifact optimization.
-The system operates on the minimal abstraction of an (Artifact, Eval, Agent)
-triplet: given any measurable artifact and an evaluation function, an LLM
-agent generates informed mutations, the engine evaluates them under
-statistical rigor, and a search strategy decides whether to accept or
-revert each change.
+We presented \textsc{anneal}, a domain-agnostic framework that brings statistical decision theory to the accept/reject boundary of iterative LLM-guided artifact optimization.
+The system operates on the minimal abstraction of an (Artifact, Eval, Agent) triplet: given any measurable artifact and an evaluation function, an LLM agent generates informed mutations, the engine evaluates them under statistical rigor, and a search strategy decides whether to accept or revert each change.
 Every experiment is git-committed, scope-enforced, and logged.
 
-The framework's three technical contributions (statistical acceptance
-under stochastic evaluation, adaptive metaheuristic search, and structured
-episodic knowledge retrieval) are each validated as an independent
-mechanism in \cref{sec:results}.
-Holm--Bonferroni correction reduces false-positive acceptance by 86\% under
-a synthetic null distribution (\cref{sec:gate-false-positives}), adaptive
-simulated annealing yields a 19.1\% improvement over fixed cooling on the
-3D Rastrigin function (\cref{sec:gate-sa}), and TF-IDF retrieval achieves
-$1.55\times$ the precision of Jaccard similarity on a controlled corpus
-(\cref{sec:gate-retrieval}).
-These mechanism-level results are supported by two architectural
-contributions (git-native isolation with scope enforcement, and a
-domain-agnostic artifact--evaluation interface) that realize the framework
-as an integrated, reproducible research artifact.
+The framework's three technical contributions (statistical acceptance under stochastic evaluation, adaptive metaheuristic search, and structured episodic knowledge retrieval) are each validated as an independent mechanism in \cref{sec:results}.
+Holm--Bonferroni correction reduces false-positive acceptance by 86\% under a synthetic null distribution (\cref{sec:gate-false-positives}), adaptive simulated annealing yields a 19.1\% improvement over fixed cooling on the 3D Rastrigin function (\cref{sec:gate-sa}), and TF-IDF retrieval achieves $1.55\times$ the precision of Jaccard similarity on a controlled corpus (\cref{sec:gate-retrieval}).
+These mechanism-level results are supported by two architectural contributions (git-native isolation with scope enforcement, and a domain-agnostic artifact--evaluation interface) that realize the framework as an integrated, reproducible research artifact.
 
-The end-to-end study of \cref{sec:end-to-end} runs four nested configurations
-(raw, greedy, control, treatment) on the five-target benchmark suite at
-$n = 5$ paired seeds.
-The full treatment configuration produces a directional improvement on
-final-score over the same engine without enhancement tracks on every target,
-ranging from $+3.5\%$ to $+44.5\%$, at cost largely comparable to control.
-After Holm--Bonferroni correction across the five-target family, no
-treatment-versus-control or treatment-versus-greedy comparison reaches
-significance at the seed count run; the two strongest greedy-versus-treatment
-effects (B3 and B5) sit at the Wilcoxon two-sided floor of $p = 0.0625$ before
-correction, indicating where a higher-powered replication would push the
-result.
-The benchmark harness, targets, analysis pipeline, and raw per-seed result
-files ship as part of the open-source distribution to enable independent
-replication and extension.
-The highest-priority extensions are higher-powered replications resolving
-the open near-significant comparisons and multi-artifact coordinated
-mutations that lift the current single-file scope (\cref{sec:future-work}).
+The end-to-end study of \cref{sec:end-to-end} runs four nested configurations (raw, greedy, control, treatment) on the five-target benchmark suite at $n = 5$ paired seeds.
+The full treatment configuration produces a directional improvement on final-score over the same engine without enhancement tracks on every target, ranging from $+3.5\%$ to $+44.5\%$, at cost largely comparable to control.
+After Holm--Bonferroni correction across the five-target family, no treatment-versus-control or treatment-versus-greedy comparison reaches significance at the seed count run; the two strongest greedy-versus-treatment effects (B3 and B5) sit at the Wilcoxon two-sided floor of $p = 0.0625$ before correction, indicating where a higher-powered replication would push the result.
+The benchmark harness, targets, analysis pipeline, and raw per-seed result files ship as part of the open-source distribution to enable independent replication and extension.
+The highest-priority extensions are higher-powered replications resolving the open near-significant comparisons and multi-artifact coordinated mutations that lift the current single-file scope (\cref{sec:future-work}).
 
-\textsc{anneal} is available under the Apache-2.0 license at
-\url{https://github.com/Mathews-Tom/anneal} and as the \texttt{anneal-cli}
-package on PyPI.
+\textsc{anneal} is available under the Apache-2.0 license at \url{https://github.com/Mathews-Tom/anneal} and as the \texttt{anneal-cli} package on PyPI.

--- a/paper/sections/conclusion.tex
+++ b/paper/sections/conclusion.tex
@@ -1,4 +1,3 @@
-% !TEX root = ../main.tex
 \section{Conclusion}
 \label{sec:conclusion}
 

--- a/paper/sections/discussion.tex
+++ b/paper/sections/discussion.tex
@@ -13,8 +13,8 @@ signature and its call sites must either be proposed as a single multi-file
 patch by one agent or deferred across multiple experiment cycles.
 The current architecture does not support multi-agent coordination with
 conflict resolution or merge semantics, so optimization targets whose
-improvements fundamentally require parallel specialization---one agent
-refactoring structure while another refines documentation---fall outside the
+improvements fundamentally require parallel specialization (one agent
+refactoring structure while another refines documentation) fall outside the
 framework's reach.
 
 \paragraph{Text artifacts only.}
@@ -26,7 +26,7 @@ Optimization targets requiring deployment to external systems (email campaigns, 
 Stochastic evaluation relies on an LLM judge scoring against binary criteria.
 The quality of optimization is bounded by the quality of the judge: a judge that rewards superficial keyword matching will drive the optimizer toward keyword-stuffed artifacts.
 Position debiasing (\cref{sec:eval-pipeline}) and held-out validation mitigate systematic judge bias, but they do not eliminate it.
-Practitioners must invest in evaluation design---clear, unambiguous criteria with concrete acceptance thresholds---to obtain meaningful optimization trajectories.
+Practitioners must invest in evaluation design (clear, unambiguous criteria with concrete acceptance thresholds) to obtain meaningful optimization trajectories.
 
 \paragraph{Cost.}
 A full optimization run of 50 experiments incurs substantial LLM API cost, with the exact figure depending on the evaluation mode, the number of stochastic samples per experiment, and the selected models for the mutation, diagnosis, and judgment roles.
@@ -49,7 +49,7 @@ API pricing variability (model version updates, rate limit throttling) introduce
 The end-to-end comparison in \cref{sec:end-to-end} runs at $n = 5$ paired seeds per target across five targets.
 At this seed count the Wilcoxon signed-rank test has a two-sided $p$-value floor of $0.0625$, so no comparison can reach the conventional $\alpha = 0.05$ threshold per-target without ties or unusual sign patterns, and after Holm--Bonferroni correction across five targets the bar rises further still.
 The directional pattern across targets (treatment beats control on 5/5 targets, treatment beats greedy on 5/5 targets) and the Cohen's-large effect sizes on the two near-significant greedy-versus-treatment comparisons (B3, $d = -1.09$; B5, $d = 1.35$) together indicate that the seed count, not the magnitude of the underlying effect, is the binding constraint on whether systemic claims clear the corrected threshold.
-A higher-powered replication---larger $n$ per target, or a study restricted to one or two targets that does not pay the five-target multiplicity tax---would resolve whether the directional advantage of the full treatment configuration translates into a statistically defensible claim.
+A higher-powered replication (larger $n$ per target, or a study restricted to one or two targets that does not pay the five-target multiplicity tax) would resolve whether the directional advantage of the full treatment configuration translates into a statistically defensible claim.
 We have intentionally not run such a replication at this stage because the seed-counted result with its honest non-significance is more informative than a cherry-picked single-target study would be: it illustrates exactly the conservatism the framework's statistical-acceptance layer is designed to enforce.
 The domain-agnostic design claim in \cref{sec:introduction} continues to rest primarily on the architecture of the artifact--evaluation--agent triplet (\cref{sec:triplet}); the suite spans prompts, code, and documentation, but five targets cannot establish that the framework composes into improvements across the broader space of text-artifact optimization problems.
 
@@ -66,7 +66,7 @@ The benchmark targets ship with criteria that are phrased as concrete yes/no que
 This investment in criterion design is itself a limitation: in practice, users may not invest equivalent effort, leading to lower optimization effectiveness than the benchmark design suggests.
 
 \paragraph{Proxy gaming and rubric-facing optimization.}
-The architectural separation in \cref{sec:triplet}---immutable eval definitions, an agent that never sees the eval command, scope enforcement that blocks edits to scoring code---prevents the agent from modifying the evaluation function itself.
+The architectural separation in \cref{sec:triplet} (immutable eval definitions, an agent that never sees the eval command, scope enforcement that blocks edits to scoring code) prevents the agent from modifying the evaluation function itself.
 It does not prevent the agent from optimizing the evaluation function as it is written.
 On stochastic-eval targets, an agent can learn to produce artifacts that score well on the rubric criteria as phrased even when the produced artifact does not match the rubric's intent: rubric-facing language that satisfies a binary keyword check, formatting choices that satisfy a structural criterion without addressing the underlying quality the criterion is meant to proxy, or coverage of all listed cases without depth on any of them.
 On deterministic-eval targets, an agent can overfit to the test fixtures: passing the specific inputs the harness exercises while degrading on inputs the harness does not exercise.
@@ -82,7 +82,7 @@ The two strongest greedy-versus-treatment comparisons (B3, B5) sit at the Wilcox
 A replication at higher seed counts on a smaller subset of targets would resolve whether the directional advantage translates into a statistically defensible claim.
 
 \paragraph{Multi-artifact optimization.}
-Extending the mutation scope to coordinated changes across multiple files---e.g., modifying a function signature and all its call sites simultaneously---would enable structural refactoring that single-file mutations cannot achieve.
+Extending the mutation scope to coordinated changes across multiple files (e.g., modifying a function signature and all its call sites simultaneously) would enable structural refactoring that single-file mutations cannot achieve.
 This requires dependency-aware scoping and atomic multi-file commits with rollback semantics, both of which the git environment backend supports in principle.
 
 \paragraph{Typed evaluator protocol.}
@@ -99,4 +99,4 @@ The scheduler and daemon management components are implemented; the remaining wo
 
 \paragraph{IDE integration.}
 Embedding the optimization loop into editor extensions (VS Code, JetBrains) would reduce the barrier to adoption by allowing developers to trigger optimization on selected files without leaving their editor.
-The engine's file-based architecture (JSONL logs, file-based SSE dashboard) is compatible with extension integration, but the UX design---progress visualization, result acceptance, inline diff preview---remains open.
+The engine's file-based architecture (JSONL logs, file-based SSE dashboard) is compatible with extension integration, but the UX design (progress visualization, result acceptance, inline diff preview) remains open.

--- a/paper/sections/discussion.tex
+++ b/paper/sections/discussion.tex
@@ -1,3 +1,4 @@
+% !TEX root = ../main.tex
 \section{Discussion}
 \label{sec:discussion}
 

--- a/paper/sections/discussion.tex
+++ b/paper/sections/discussion.tex
@@ -1,4 +1,3 @@
-% !TEX root = ../main.tex
 \section{Discussion}
 \label{sec:discussion}
 

--- a/paper/sections/discussion.tex
+++ b/paper/sections/discussion.tex
@@ -6,16 +6,8 @@
 \label{sec:limitations}
 
 \paragraph{Single-agent mutation.}
-Each experiment cycle invokes exactly one mutation agent that edits the
-artifact in isolation, so mutations that require coordinated changes across
-interacting files cannot be generated atomically: an edit to a function
-signature and its call sites must either be proposed as a single multi-file
-patch by one agent or deferred across multiple experiment cycles.
-The current architecture does not support multi-agent coordination with
-conflict resolution or merge semantics, so optimization targets whose
-improvements fundamentally require parallel specialization (one agent
-refactoring structure while another refines documentation) fall outside the
-framework's reach.
+Each experiment cycle invokes exactly one mutation agent that edits the artifact in isolation, so mutations that require coordinated changes across interacting files cannot be generated atomically: an edit to a function signature and its call sites must either be proposed as a single multi-file patch by one agent or deferred across multiple experiment cycles.
+The current architecture does not support multi-agent coordination with conflict resolution or merge semantics, so optimization targets whose improvements fundamentally require parallel specialization (one agent refactoring structure while another refines documentation) fall outside the framework's reach.
 
 \paragraph{Text artifacts only.}
 The engine operates on file-based text artifacts versioned in git.

--- a/paper/sections/enhancements.tex
+++ b/paper/sections/enhancements.tex
@@ -37,7 +37,7 @@ Compression reduces input token cost and keeps the agent within its context wind
 
 \subsubsection{Dual-Agent Mutation via Thompson Sampling}\label{sec:dual-agent}
 
-The \texttt{Agent\allowbreak{}Selector} class (\texttt{anneal/\allowbreak{}engine/\allowbreak{}strategy\allowbreak{}\_selector.py}) maintains two Beta-Binomial arms---\texttt{primary} and \texttt{exploration}---and selects between them using Thompson Sampling.
+The \texttt{Agent\allowbreak{}Selector} class (\texttt{anneal/\allowbreak{}engine/\allowbreak{}strategy\allowbreak{}\_selector.py}) maintains two Beta-Binomial arms (\texttt{primary} and \texttt{exploration}) and selects between them using Thompson Sampling.
 The primary agent uses the model and temperature specified in \texttt{Agent\allowbreak{}Config}; the exploration agent uses a separate model (\texttt{exploration\allowbreak{}\_model}) at higher temperature, biased toward novel mutations.
 
 Selection is modulated by experiment progress: early in the run (\texttt{experiment\_ratio} $< 0.2$), exploration receives a $1.4\times$ boost; late in the run ($> 0.8$), exploration is dampened to $0.4\times$ its posterior sample.
@@ -132,7 +132,7 @@ This mechanism reduces cost on clear-cut experiments while increasing statistica
 
 \subsubsection{Eval Consistency Monitoring}\label{sec:drift-detection}
 
-Evaluator drift---where the same artifact receives different scores over time---undermines the optimization signal.
+Evaluator drift (where the same artifact receives different scores over time) undermines the optimization signal.
 The \texttt{KnowledgeStore.get\_drift\_report} method detects drift using a sliding-window comparison: within the most recent consolidation window, it splits records into first and second halves and flags any criterion whose variance increased by more than $2\times$ between halves, or whose total variance exceeds a threshold (default $0.1$).
 Flagged criteria are reported as \texttt{DriftEntry} objects containing the criterion name, variance, mean score, and window size.
 
@@ -145,7 +145,7 @@ When the agent produces a mutation identical to a previously evaluated artifact,
 The \texttt{EvalCache} (\texttt{anneal/engine/eval\_cache.py}) is a content-addressed LRU cache keyed on the SHA-256 hash of the artifact content concatenated with the sorted criterion names.
 On a cache hit, the stored \texttt{CacheEntry} (score, raw scores, criterion names) is returned immediately.
 
-The cache also tracks \texttt{score\_history}---the sequence of scores observed for the same content hash across multiple evaluations.
+The cache also tracks \texttt{score\_history}: the sequence of scores observed for the same content hash across multiple evaluations.
 The \texttt{consistency\_report} method flags entries where the standard deviation across evaluations exceeds $0.1$, surfacing potential evaluator inconsistency independent of the drift detection in the knowledge store.
 Maximum cache size is configurable (default 200 entries) with LRU eviction.
 

--- a/paper/sections/enhancements.tex
+++ b/paper/sections/enhancements.tex
@@ -1,3 +1,4 @@
+% !TEX root = ../main.tex
 \section{Enhancements}\label{sec:enhancements}
 
 The base system described in \cref{sec:system-design} operates with greedy search, flat mutation instructions, and no cross-experiment memory.

--- a/paper/sections/enhancements.tex
+++ b/paper/sections/enhancements.tex
@@ -24,7 +24,8 @@ Migration from \texttt{program.md} is automatic: \texttt{migrate\_program\_md} c
 
 \subsubsection{Token-Efficient Context}\label{sec:context-compression}
 
-Agent context grows with experiment history. The \texttt{context\_compression} field on \texttt{AgentConfig} supports three modes:
+Agent context grows with experiment history.
+The \texttt{context\_compression} field on \texttt{AgentConfig} supports three modes:
 \begin{itemize}
     \item \texttt{none}: full context (experiment records, artifact content, knowledge).
     \item \texttt{moderate}: recent experiment records are truncated to hypothesis and outcome; full artifact content is retained.

--- a/paper/sections/enhancements.tex
+++ b/paper/sections/enhancements.tex
@@ -1,4 +1,3 @@
-% !TEX root = ../main.tex
 \section{Enhancements}\label{sec:enhancements}
 
 The base system described in \cref{sec:system-design} operates with greedy search, flat mutation instructions, and no cross-experiment memory.

--- a/paper/sections/evaluation.tex
+++ b/paper/sections/evaluation.tex
@@ -1,3 +1,4 @@
+% !TEX root = ../main.tex
 \section{Benchmark Suite}
 \label{sec:evaluation}
 

--- a/paper/sections/evaluation.tex
+++ b/paper/sections/evaluation.tex
@@ -2,12 +2,8 @@
 \section{Benchmark Suite}
 \label{sec:evaluation}
 
-\textsc{anneal} ships with a benchmark suite of five optimization targets
-spanning three domains (prompt optimization, code optimization, and
-documentation generation) that exercise both evaluation modes (deterministic
-and stochastic) and a range of optimization objectives.
-The suite is part of the open-source distribution and is intended as a
-reproducible reference workload for end-to-end configuration comparison.
+\textsc{anneal} ships with a benchmark suite of five optimization targets spanning three domains (prompt optimization, code optimization, and documentation generation) that exercise both evaluation modes (deterministic and stochastic) and a range of optimization objectives.
+The suite is part of the open-source distribution and is intended as a reproducible reference workload for end-to-end configuration comparison.
 The mechanism-level validation in \cref{sec:gate-false-positives,sec:gate-sa,sec:gate-retrieval} uses synthetic benchmarks with analytically known ground truth to isolate individual subsystems, and the end-to-end comparison in \cref{sec:end-to-end} runs the full benchmark suite under the four-configuration protocol described below.
 This section documents the suite's targets and the statistical protocol applied to the end-to-end run.
 
@@ -15,9 +11,7 @@ This section documents the suite's targets and the statistical protocol applied 
 \label{sec:benchmark-suite}
 
 \cref{tab:benchmark-targets} summarizes the five benchmark targets.
-Each target defines an artifact, an evaluation function, and a set of
-editable files; the evaluation function and its criteria are immutable and
-outside the agent's mutation scope.
+Each target defines an artifact, an evaluation function, and a set of editable files; the evaluation function and its criteria are immutable and outside the agent's mutation scope.
 
 \begin{table}[t]
   \centering
@@ -38,76 +32,35 @@ outside the agent's mutation scope.
 \end{table}
 
 The targets were selected to satisfy three coverage criteria.
-First, they span both evaluation modes: B3 and B4 use deterministic
-evaluation (a single scalar from a shell command: wall-clock time and a
-composite quality score, respectively), while B1, B2, and B5 use the
-$N \times K$ stochastic evaluation framework with binary criteria.
-Second, they cover three distinct optimization domains (prompt engineering,
-code transformation, and technical writing) so that results are not
-tied to a single domain.
-Third, they exercise different optimization directions: maximization
-(B1, B2, B4, B5) and minimization (B3), testing the engine's directional
-generality.
+First, they span both evaluation modes: B3 and B4 use deterministic evaluation (a single scalar from a shell command: wall-clock time and a composite quality score, respectively), while B1, B2, and B5 use the $N \times K$ stochastic evaluation framework with binary criteria.
+Second, they cover three distinct optimization domains (prompt engineering, code transformation, and technical writing) so that results are not tied to a single domain.
+Third, they exercise different optimization directions: maximization (B1, B2, B4, B5) and minimization (B3), testing the engine's directional generality.
 
-Each target ships with a TOML configuration specifying artifact paths,
-scope constraints, evaluation commands, and scoring criteria.
-The evaluation functions are self-contained: B3 runs a subprocess and
-parses wall-clock time; B4 runs a composite quality scorer (covering
-correctness, input validation, error handling, and security); B1, B2, and
-B5 invoke an LLM judge with fixed rubric criteria and aggregate binary
-pass/fail scores across $N = 5$ test prompts.
+Each target ships with a TOML configuration specifying artifact paths, scope constraints, evaluation commands, and scoring criteria.
+The evaluation functions are self-contained: B3 runs a subprocess and parses wall-clock time; B4 runs a composite quality scorer (covering correctness, input validation, error handling, and security); B1, B2, and B5 invoke an LLM judge with fixed rubric criteria and aggregate binary pass/fail scores across $N = 5$ test prompts.
 
-The harness ships four nested-ablation configurations (raw, greedy, control,
-treatment) defined in \texttt{benchmarks/suite/runner.py} for end-to-end
-comparison.
-\Cref{tab:e2e-configs} documents the layer each configuration adds, and
-\cref{sec:end-to-end} reports the full empirical comparison.
+The harness ships four nested-ablation configurations (raw, greedy, control, treatment) defined in \texttt{benchmarks/suite/runner.py} for end-to-end comparison.
+\Cref{tab:e2e-configs} documents the layer each configuration adds, and \cref{sec:end-to-end} reports the full empirical comparison.
 
 \subsection{Statistical Design for End-to-End Comparison}
 \label{sec:stat-design}
 
-The harness implements a paired-seed experimental design for comparing
-configurations.
-Each configuration runs 5 independent trials per benchmark target, each
-with a distinct random seed that controls LLM sampling temperature jitter
-and stochastic evaluation order.
-Every trial executes 50 experiments (mutations), yielding a total
-experimental budget of
-$5 \text{ targets} \times 4 \text{ configs} \times 5 \text{ runs}
- \times 50 \text{ experiments} = 5{,}000$ experiments for the end-to-end
-comparison reported in \cref{sec:end-to-end}.
-The harness supports larger seed counts; we report results at $n = 5$
-because it is the smallest paired-seed count at which the Wilcoxon
-signed-rank test attains a usable two-sided $p$-value floor of $0.0625$,
-and it places a deliberate lower bound on statistical power so that
-significant findings must clear a meaningful effect-size bar
-(\cref{sec:end-to-end-significance}).
+The harness implements a paired-seed experimental design for comparing configurations.
+Each configuration runs 5 independent trials per benchmark target, each with a distinct random seed that controls LLM sampling temperature jitter and stochastic evaluation order.
+Every trial executes 50 experiments (mutations), yielding a total experimental budget of $5 \text{ targets} \times 4 \text{ configs} \times 5 \text{ runs} \times 50 \text{ experiments} = 5{,}000$ experiments for the end-to-end comparison reported in \cref{sec:end-to-end}.
+The harness supports larger seed counts; we report results at $n = 5$ because it is the smallest paired-seed count at which the Wilcoxon signed-rank test attains a usable two-sided $p$-value floor of $0.0625$, and it places a deliberate lower bound on statistical power so that significant findings must clear a meaningful effect-size bar (\cref{sec:end-to-end-significance}).
 
 \paragraph{Pairwise comparison.}
-For each pair of configurations on each target, the harness applies the
-Wilcoxon signed-rank test across the 5 paired final scores (paired by
-random seed).
-This nonparametric test is appropriate because score distributions are
-not assumed normal, and pairing by seed controls for LLM sampling
-variability.
+For each pair of configurations on each target, the harness applies the Wilcoxon signed-rank test across the 5 paired final scores (paired by random seed).
+This nonparametric test is appropriate because score distributions are not assumed normal, and pairing by seed controls for LLM sampling variability.
 
 \paragraph{Multiple comparison correction.}
-Holm--Bonferroni correction is applied across the five targets for each
-configuration pair, controlling the family-wise error rate at
-$\alpha = 0.05$.
-This mirrors the correction used within the engine itself for
-consolidation-window decisions (\cref{sec:stat-comparison}).
+Holm--Bonferroni correction is applied across the five targets for each configuration pair, controlling the family-wise error rate at $\alpha = 0.05$.
+This mirrors the correction used within the engine itself for consolidation-window decisions (\cref{sec:stat-comparison}).
 
 \paragraph{Effect size.}
-The harness reports Cohen's $d$ with 95\% bootstrap confidence intervals
-(10{,}000 resamples, bias-corrected and accelerated) using the bootstrap
-methodology of Efron and Tibshirani~\cite{efron1994bootstrap}.
-Bootstrap resampling uses deterministic seeding with float-precision
-normalization for cross-platform reproducibility.
+The harness reports Cohen's $d$ with 95\% bootstrap confidence intervals (10{,}000 resamples, bias-corrected and accelerated) using the bootstrap methodology of Efron and Tibshirani~\cite{efron1994bootstrap}.
+Bootstrap resampling uses deterministic seeding with float-precision normalization for cross-platform reproducibility.
 
 \paragraph{Cost-normalized comparison.}
-Because the treatment configuration incurs higher per-experiment cost
-(two-phase mutation, multi-draft generation), the harness also supports
-score-at-equivalent-budget comparison: the best score each configuration
-achieves when constrained to the same total USD cost, rather than the same
-number of experiments.
+Because the treatment configuration incurs higher per-experiment cost (two-phase mutation, multi-draft generation), the harness also supports score-at-equivalent-budget comparison: the best score each configuration achieves when constrained to the same total USD cost, rather than the same number of experiments.

--- a/paper/sections/evaluation.tex
+++ b/paper/sections/evaluation.tex
@@ -3,8 +3,8 @@
 \label{sec:evaluation}
 
 \textsc{anneal} ships with a benchmark suite of five optimization targets
-spanning three domains---prompt optimization, code optimization, and
-documentation generation---that exercise both evaluation modes (deterministic
+spanning three domains (prompt optimization, code optimization, and
+documentation generation) that exercise both evaluation modes (deterministic
 and stochastic) and a range of optimization objectives.
 The suite is part of the open-source distribution and is intended as a
 reproducible reference workload for end-to-end configuration comparison.
@@ -39,11 +39,11 @@ outside the agent's mutation scope.
 
 The targets were selected to satisfy three coverage criteria.
 First, they span both evaluation modes: B3 and B4 use deterministic
-evaluation (a single scalar from a shell command---wall-clock time and a
+evaluation (a single scalar from a shell command: wall-clock time and a
 composite quality score, respectively), while B1, B2, and B5 use the
 $N \times K$ stochastic evaluation framework with binary criteria.
-Second, they cover three distinct optimization domains---prompt engineering,
-code transformation, and technical writing---so that results are not
+Second, they cover three distinct optimization domains (prompt engineering,
+code transformation, and technical writing) so that results are not
 tied to a single domain.
 Third, they exercise different optimization directions: maximization
 (B1, B2, B4, B5) and minimization (B3), testing the engine's directional

--- a/paper/sections/evaluation.tex
+++ b/paper/sections/evaluation.tex
@@ -1,4 +1,3 @@
-% !TEX root = ../main.tex
 \section{Benchmark Suite}
 \label{sec:evaluation}
 

--- a/paper/sections/introduction.tex
+++ b/paper/sections/introduction.tex
@@ -1,3 +1,4 @@
+% !TEX root = ../main.tex
 \section{Introduction}
 \label{sec:introduction}
 

--- a/paper/sections/introduction.tex
+++ b/paper/sections/introduction.tex
@@ -1,120 +1,63 @@
 \section{Introduction}
 \label{sec:introduction}
 
-Large language models have demonstrated a striking capacity to act as
-optimization oracles: given a text artifact and a description of what ``better''
-means, an LLM can propose targeted mutations that improve performance on
-measurable objectives~\cite{novikov2025alphaevolve, romera2024funsearch}.
-This capability extends far beyond code: prompts, configuration files, system
-instructions, and any other text-based artifact amenable to automated evaluation
-are candidates for LLM-guided search.
-Yet the gap between ``an LLM can suggest edits'' and ``an LLM reliably improves
-artifacts'' remains wide.
-Bridging it requires solving four interrelated problems that current tools
-address only partially, if at all.
+Large language models have demonstrated a striking capacity to act as optimization oracles: given a text artifact and a description of what ``better'' means, an LLM can propose targeted mutations that improve performance on measurable objectives~\cite{novikov2025alphaevolve, romera2024funsearch}.
+This capability extends far beyond code: prompts, configuration files, system instructions, and any other text-based artifact amenable to automated evaluation are candidates for LLM-guided search.
+Yet the gap between ``an LLM can suggest edits'' and ``an LLM reliably improves artifacts'' remains wide.
+Bridging it requires solving four interrelated problems that current tools address only partially, if at all.
 
 \paragraph{Statistical rigor.}
-When evaluation is stochastic (an LLM judge scoring prompt outputs, a noisy
-benchmark, a test suite with non-deterministic ordering), raw score comparisons
-are unreliable.
-A candidate that scores 0.82 versus a baseline of 0.80 may reflect genuine
-improvement or sampling noise.
-Prompt optimization tools such as DSPy~\cite{khattab2024dspy} and
-EvoPrompt~\cite{guo2023evoprompt} typically compare mean scores without
-hypothesis testing, leading to false-positive acceptances that compound over
-sequential experiments.
-The machine learning evaluation literature has long warned against this
-practice~\cite{dror2018hitchhiker}, yet optimization frameworks rarely
-incorporate the recommended statistical machinery.
+When evaluation is stochastic (an LLM judge scoring prompt outputs, a noisy benchmark, a test suite with non-deterministic ordering), raw score comparisons are unreliable.
+A candidate that scores 0.82 versus a baseline of 0.80 may reflect genuine improvement or sampling noise.
+Prompt optimization tools such as DSPy~\cite{khattab2024dspy} and EvoPrompt~\cite{guo2023evoprompt} typically compare mean scores without hypothesis testing, leading to false-positive acceptances that compound over sequential experiments.
+The machine learning evaluation literature has long warned against this practice~\cite{dror2018hitchhiker}, yet optimization frameworks rarely incorporate the recommended statistical machinery.
 
 \paragraph{Structured search.}
-Most LLM-guided optimization systems use greedy hill-climbing: accept an edit if
-the score improves, reject otherwise.
-Greedy search is prone to local optima, particularly in the combinatorial space
-of text mutations where small edits can interact non-linearly.
-Metaheuristic search (simulated annealing, population-based methods, bandit
-algorithms) offers well-understood mechanisms for escaping local optima and
-balancing exploration with exploitation, yet these strategies have seen limited
-adoption in LLM-guided settings.
-AlphaEvolve~\cite{novikov2025alphaevolve} uses an island-based evolutionary
-approach but is tightly coupled to code optimization;
-Promptbreeder~\cite{fernando2024promptbreeder} evolves mutation operators but
-provides no formal search strategy selection.
+Most LLM-guided optimization systems use greedy hill-climbing: accept an edit if the score improves, reject otherwise.
+Greedy search is prone to local optima, particularly in the combinatorial space of text mutations where small edits can interact non-linearly.
+Metaheuristic search (simulated annealing, population-based methods, bandit algorithms) offers well-understood mechanisms for escaping local optima and balancing exploration with exploitation, yet these strategies have seen limited adoption in LLM-guided settings.
+AlphaEvolve~\cite{novikov2025alphaevolve} uses an island-based evolutionary approach but is tightly coupled to code optimization; Promptbreeder~\cite{fernando2024promptbreeder} evolves mutation operators but provides no formal search strategy selection.
 
 \paragraph{Knowledge accumulation.}
-Each experiment in an optimization run generates information: what changed, what
-improved, what regressed, and why.
-Current systems discard this information after the accept/reject decision,
-forcing the optimizer to rediscover lessons from prior experiments.
-Effective optimization requires episodic memory (structured records of past
-experiments that inform future mutations) and cross-target knowledge transfer
-that lets insights from one optimization task accelerate another.
+Each experiment in an optimization run generates information: what changed, what improved, what regressed, and why.
+Current systems discard this information after the accept/reject decision, forcing the optimizer to rediscover lessons from prior experiments.
+Effective optimization requires episodic memory (structured records of past experiments that inform future mutations) and cross-target knowledge transfer that lets insights from one optimization task accelerate another.
 
 \paragraph{Safety and reproducibility.}
-LLM-guided optimization involves executing generated code, running evaluation
-commands, and making irreversible file changes.
-Without isolation, a bad mutation can corrupt the working directory; without
-budget controls, a stochastic evaluation loop can exhaust API credits overnight.
-Reproducibility demands that every experiment state be recoverable, every
-comparison be auditable, and every cost be tracked.
+LLM-guided optimization involves executing generated code, running evaluation commands, and making irreversible file changes.
+Without isolation, a bad mutation can corrupt the working directory; without budget controls, a stochastic evaluation loop can exhaust API credits overnight.
+Reproducibility demands that every experiment state be recoverable, every comparison be auditable, and every cost be tracked.
 
 \medskip
 
 No existing system addresses all four concerns simultaneously.
-DSPy~\cite{khattab2024dspy} and OPRO~\cite{yang2024opro} focus on prompt
-optimization without structured search or statistical testing.
-AlphaEvolve~\cite{novikov2025alphaevolve} provides evolutionary search for code
-but lacks statistical comparison and knowledge transfer.
-ProTeGi~\cite{pryzant2023protegi} uses gradient-inspired textual feedback but
-operates greedily with no memory.
-FunSearch~\cite{romera2024funsearch} pairs LLMs with evaluators but is
-restricted to function-level code search with best-shot selection.
+DSPy~\cite{khattab2024dspy} and OPRO~\cite{yang2024opro} focus on prompt optimization without structured search or statistical testing.
+AlphaEvolve~\cite{novikov2025alphaevolve} provides evolutionary search for code but lacks statistical comparison and knowledge transfer.
+ProTeGi~\cite{pryzant2023protegi} uses gradient-inspired textual feedback but operates greedily with no memory.
+FunSearch~\cite{romera2024funsearch} pairs LLMs with evaluators but is restricted to function-level code search with best-shot selection.
 
 \subsection{Contributions}
 
-We present \textsc{anneal}, an open-source framework for autonomous artifact
-optimization that addresses the four gaps above.
-The framework makes three technical contributions (each validated as an
-independent mechanism in \cref{sec:results}) supported by two architectural
-contributions that realize the framework as an integrated, reproducible
-research artifact.
+We present \textsc{anneal}, an open-source framework for autonomous artifact optimization that addresses the four gaps above.
+The framework makes three technical contributions (each validated as an independent mechanism in \cref{sec:results}) supported by two architectural contributions that realize the framework as an integrated, reproducible research artifact.
 
 \paragraph{Technical contributions (validated in \cref{sec:results}).}
 
 \begin{enumerate}
-  \item \textbf{Statistical acceptance under stochastic evaluation}
-    (\cref{sec:gate-false-positives}).
-    Stochastic evaluations are compared via the Wilcoxon signed-rank
-    test~\cite{wilcoxon1945individual} with Holm--Bonferroni
-    correction~\cite{holm1979simple} for sequential multiplicity.
-    Position-bias-cancelled Bradley--Terry scoring~\cite{bradley1952rank}
-    calibrates the LLM judge, and adaptive sample sizing extends or
-    early-stops evaluation based on the observed effect size.
-    On a synthetic null distribution, Holm--Bonferroni correction reduces
-    false-positive acceptance by 86\% relative to uncorrected thresholding.
+  \item \textbf{Statistical acceptance under stochastic evaluation} (\cref{sec:gate-false-positives}).
+    Stochastic evaluations are compared via the Wilcoxon signed-rank test~\cite{wilcoxon1945individual} with Holm--Bonferroni correction~\cite{holm1979simple} for sequential multiplicity.
+    Position-bias-cancelled Bradley--Terry scoring~\cite{bradley1952rank} calibrates the LLM judge, and adaptive sample sizing extends or early-stops evaluation based on the observed effect size.
+    On a synthetic null distribution, Holm--Bonferroni correction reduces false-positive acceptance by 86\% relative to uncorrected thresholding.
 
-  \item \textbf{Adaptive metaheuristic search}
-    (\cref{sec:gate-sa}).
-    Beyond greedy hill-climbing, \textsc{anneal} implements simulated
-    annealing with adaptive cooling and reheat, population-based search with
-    tournament selection and LLM-guided crossover, island migration for
-    diversity maintenance, and Pareto search for multi-objective optimization.
-    A Thompson Sampling meta-strategy~\cite{thompson1933likelihood,
-    chapelle2011empirical} selects among these algorithms based on observed
-    reward, treating strategy selection itself as a bandit problem.
-    On the 3D Rastrigin function, adaptive reheat yields a 19.1\% improvement
-    over fixed geometric cooling.
+  \item \textbf{Adaptive metaheuristic search} (\cref{sec:gate-sa}).
+    Beyond greedy hill-climbing, \textsc{anneal} implements simulated annealing with adaptive cooling and reheat, population-based search with tournament selection and LLM-guided crossover, island migration for diversity maintenance, and Pareto search for multi-objective optimization.
+    A Thompson Sampling meta-strategy~\cite{thompson1933likelihood, chapelle2011empirical} selects among these algorithms based on observed reward, treating strategy selection itself as a bandit problem.
+    On the 3D Rastrigin function, adaptive reheat yields a 19.1\% improvement over fixed geometric cooling.
 
-  \item \textbf{Structured episodic knowledge retrieval}
-    (\cref{sec:gate-retrieval}).
-    Each experiment produces a structured \texttt{Lesson} capturing what
-    changed, which criteria improved or regressed, and transferable insights.
-    A cross-target learning pool shares knowledge across optimization tasks
-    with domain-aware relevance filtering, a strategy manifest evolves the
-    weakest component of the mutation approach when progress stalls, and a
-    research operator injects external knowledge during plateaus.
-    On a controlled similarity corpus, TF-IDF retrieval achieves
-    $1.55\times$ the precision of Jaccard similarity.
+  \item \textbf{Structured episodic knowledge retrieval} (\cref{sec:gate-retrieval}).
+    Each experiment produces a structured \texttt{Lesson} capturing what changed, which criteria improved or regressed, and transferable insights.
+    A cross-target learning pool shares knowledge across optimization tasks with domain-aware relevance filtering, a strategy manifest evolves the weakest component of the mutation approach when progress stalls, and a research operator injects external knowledge during plateaus.
+    On a controlled similarity corpus, TF-IDF retrieval achieves $1.55\times$ the precision of Jaccard similarity.
 \end{enumerate}
 
 \paragraph{Architectural contributions (argued from design).}
@@ -122,57 +65,29 @@ research artifact.
 \begin{enumerate}
   \setcounter{enumi}{3}
   \item \textbf{Git-native isolation and safety.}
-    Every experiment runs in a dedicated git worktree, making all mutations
-    reversible via \texttt{git reset}.
-    Scope enforcement restricts agent edits to declared file paths, rejecting
-    path traversal and absolute paths.
-    Budget caps (per-experiment and daily), cost tracking per model, disk
-    space checks, and process-group time-boxing prevent runaway resource
-    consumption.
+    Every experiment runs in a dedicated git worktree, making all mutations reversible via \texttt{git reset}.
+    Scope enforcement restricts agent edits to declared file paths, rejecting path traversal and absolute paths.
+    Budget caps (per-experiment and daily), cost tracking per model, disk space checks, and process-group time-boxing prevent runaway resource consumption.
 
   \item \textbf{Domain-agnostic design.}
-    The framework optimizes any text artifact evaluable by a shell command
-    (deterministic mode) or an LLM judge against binary criteria (stochastic
-    mode), with no domain-specific assumptions.
-    Verification gates (binary pass/fail commands run before evaluation) let
-    users enforce structural invariants (compilation, type-checking, format
-    compliance) without spending evaluation budget on structurally invalid
-    mutations.
+    The framework optimizes any text artifact evaluable by a shell command (deterministic mode) or an LLM judge against binary criteria (stochastic mode), with no domain-specific assumptions.
+    Verification gates (binary pass/fail commands run before evaluation) let users enforce structural invariants (compilation, type-checking, format compliance) without spending evaluation budget on structurally invalid mutations.
 \end{enumerate}
 
 \subsection{Validation Approach}
 
 We validate \textsc{anneal} along two complementary axes.
-First, we isolate each of the three central mechanisms (statistical
-acceptance, adaptive metaheuristic search, and structured knowledge
-retrieval) on synthetic benchmarks with analytically known ground truth and
-compare against well-defined baselines: uncorrected sequential testing under
-a null distribution, fixed-schedule simulated annealing on a nonconvex
-testbed, and Jaccard set similarity on a controlled retrieval corpus.
-Second, we run an end-to-end comparison of four nested configurations (raw,
-greedy, control, treatment) on the five-target benchmark suite under the
-paired-seed protocol of \cref{sec:stat-design}.
-\Cref{sec:results} reports both: the mechanism gates pass their pre-registered
-thresholds, and the end-to-end study finds a consistent directional advantage
-of the full treatment configuration over the same engine without enhancement
-tracks on every target, with the framework's own multiplicity-corrected
-significance test declining to mark these gaps as significant at $n = 5$
-paired seeds.
-We discuss the implications of this seed count and the construct-validity
-considerations specific to LLM-judge evaluation in
-\cref{sec:empirical-scope,sec:threats}.
+First, we isolate each of the three central mechanisms (statistical acceptance, adaptive metaheuristic search, and structured knowledge retrieval) on synthetic benchmarks with analytically known ground truth and compare against well-defined baselines: uncorrected sequential testing under a null distribution, fixed-schedule simulated annealing on a nonconvex testbed, and Jaccard set similarity on a controlled retrieval corpus.
+Second, we run an end-to-end comparison of four nested configurations (raw, greedy, control, treatment) on the five-target benchmark suite under the paired-seed protocol of \cref{sec:stat-design}.
+\Cref{sec:results} reports both: the mechanism gates pass their pre-registered thresholds, and the end-to-end study finds a consistent directional advantage of the full treatment configuration over the same engine without enhancement tracks on every target, with the framework's own multiplicity-corrected significance test declining to mark these gaps as significant at $n = 5$ paired seeds.
+We discuss the implications of this seed count and the construct-validity considerations specific to LLM-judge evaluation in \cref{sec:empirical-scope,sec:threats}.
 
 \subsection{Paper Organization}
 
-\Cref{sec:related_work} surveys related work in LLM-guided optimization,
-prompt engineering, metaheuristic search, and statistical evaluation.
-\Cref{sec:system-design} describes the \textsc{anneal} architecture, including
-the experiment loop, evaluation engine, search strategies, and knowledge system.
-\Cref{sec:enhancements} details the enhancement tracks (representation, search,
-knowledge, and evaluation) that build on the core loop.
-\Cref{sec:evaluation} describes the benchmark suite and experimental design for
-end-to-end configuration comparison.
-\Cref{sec:results} presents both the mechanism-level gate validations and
-the end-to-end empirical comparison across the benchmark suite.
+\Cref{sec:related_work} surveys related work in LLM-guided optimization, prompt engineering, metaheuristic search, and statistical evaluation.
+\Cref{sec:system-design} describes the \textsc{anneal} architecture, including the experiment loop, evaluation engine, search strategies, and knowledge system.
+\Cref{sec:enhancements} details the enhancement tracks (representation, search, knowledge, and evaluation) that build on the core loop.
+\Cref{sec:evaluation} describes the benchmark suite and experimental design for end-to-end configuration comparison.
+\Cref{sec:results} presents both the mechanism-level gate validations and the end-to-end empirical comparison across the benchmark suite.
 \Cref{sec:discussion} discusses limitations and future work.
 \Cref{sec:conclusion} concludes.

--- a/paper/sections/introduction.tex
+++ b/paper/sections/introduction.tex
@@ -5,7 +5,7 @@ Large language models have demonstrated a striking capacity to act as
 optimization oracles: given a text artifact and a description of what ``better''
 means, an LLM can propose targeted mutations that improve performance on
 measurable objectives~\cite{novikov2025alphaevolve, romera2024funsearch}.
-This capability extends far beyond code---prompts, configuration files, system
+This capability extends far beyond code: prompts, configuration files, system
 instructions, and any other text-based artifact amenable to automated evaluation
 are candidates for LLM-guided search.
 Yet the gap between ``an LLM can suggest edits'' and ``an LLM reliably improves
@@ -14,8 +14,8 @@ Bridging it requires solving four interrelated problems that current tools
 address only partially, if at all.
 
 \paragraph{Statistical rigor.}
-When evaluation is stochastic---an LLM judge scoring prompt outputs, a noisy
-benchmark, a test suite with non-deterministic ordering---raw score comparisons
+When evaluation is stochastic (an LLM judge scoring prompt outputs, a noisy
+benchmark, a test suite with non-deterministic ordering), raw score comparisons
 are unreliable.
 A candidate that scores 0.82 versus a baseline of 0.80 may reflect genuine
 improvement or sampling noise.
@@ -32,8 +32,8 @@ Most LLM-guided optimization systems use greedy hill-climbing: accept an edit if
 the score improves, reject otherwise.
 Greedy search is prone to local optima, particularly in the combinatorial space
 of text mutations where small edits can interact non-linearly.
-Metaheuristic search---simulated annealing, population-based methods, bandit
-algorithms---offers well-understood mechanisms for escaping local optima and
+Metaheuristic search (simulated annealing, population-based methods, bandit
+algorithms) offers well-understood mechanisms for escaping local optima and
 balancing exploration with exploitation, yet these strategies have seen limited
 adoption in LLM-guided settings.
 AlphaEvolve~\cite{novikov2025alphaevolve} uses an island-based evolutionary
@@ -46,8 +46,8 @@ Each experiment in an optimization run generates information: what changed, what
 improved, what regressed, and why.
 Current systems discard this information after the accept/reject decision,
 forcing the optimizer to rediscover lessons from prior experiments.
-Effective optimization requires episodic memory---structured records of past
-experiments that inform future mutations---and cross-target knowledge transfer
+Effective optimization requires episodic memory (structured records of past
+experiments that inform future mutations) and cross-target knowledge transfer
 that lets insights from one optimization task accelerate another.
 
 \paragraph{Safety and reproducibility.}
@@ -74,8 +74,8 @@ restricted to function-level code search with best-shot selection.
 
 We present \textsc{anneal}, an open-source framework for autonomous artifact
 optimization that addresses the four gaps above.
-The framework makes three technical contributions---each validated as an
-independent mechanism in \cref{sec:results}---supported by two architectural
+The framework makes three technical contributions (each validated as an
+independent mechanism in \cref{sec:results}) supported by two architectural
 contributions that realize the framework as an integrated, reproducible
 research artifact.
 
@@ -134,7 +134,7 @@ research artifact.
     The framework optimizes any text artifact evaluable by a shell command
     (deterministic mode) or an LLM judge against binary criteria (stochastic
     mode), with no domain-specific assumptions.
-    Verification gates---binary pass/fail commands run before evaluation---let
+    Verification gates (binary pass/fail commands run before evaluation) let
     users enforce structural invariants (compilation, type-checking, format
     compliance) without spending evaluation budget on structurally invalid
     mutations.
@@ -143,9 +143,9 @@ research artifact.
 \subsection{Validation Approach}
 
 We validate \textsc{anneal} along two complementary axes.
-First, we isolate each of the three central mechanisms---statistical
+First, we isolate each of the three central mechanisms (statistical
 acceptance, adaptive metaheuristic search, and structured knowledge
-retrieval---on synthetic benchmarks with analytically known ground truth and
+retrieval) on synthetic benchmarks with analytically known ground truth and
 compare against well-defined baselines: uncorrected sequential testing under
 a null distribution, fixed-schedule simulated annealing on a nonconvex
 testbed, and Jaccard set similarity on a controlled retrieval corpus.
@@ -168,8 +168,8 @@ considerations specific to LLM-judge evaluation in
 prompt engineering, metaheuristic search, and statistical evaluation.
 \Cref{sec:system-design} describes the \textsc{anneal} architecture, including
 the experiment loop, evaluation engine, search strategies, and knowledge system.
-\Cref{sec:enhancements} details the enhancement tracks---representation, search,
-knowledge, and evaluation---that build on the core loop.
+\Cref{sec:enhancements} details the enhancement tracks (representation, search,
+knowledge, and evaluation) that build on the core loop.
 \Cref{sec:evaluation} describes the benchmark suite and experimental design for
 end-to-end configuration comparison.
 \Cref{sec:results} presents both the mechanism-level gate validations and

--- a/paper/sections/related_work.tex
+++ b/paper/sections/related_work.tex
@@ -1,44 +1,18 @@
 \section{Related Work}
 \label{sec:related_work}
 
-The design space of LLM-guided artifact optimization admits a spectrum of
-framework philosophies.
-At one end are minimalist scaffolds, exemplified by Karpathy's
-\texttt{autoresearch}~\cite{karpathy2025autoresearch}, that delegate almost all
-decision-making to the coding agent itself: the framework provides an
-edit--evaluate--commit loop, a single deterministic metric, and a
-human-maintained log of prior attempts, and the agent's intrinsic reasoning
-supplies acceptance judgment, search strategy, and memory of past experiments.
-This design bet is that as frontier LLMs improve, elaborate scaffolding
-becomes overhead rather than value, and that a thin framework plus a capable
-agent is sufficient for optimization on problems with clean deterministic
-metrics such as the held-out training loss of a single-GPU nanochat run.
-\textsc{anneal} draws its core experiment-loop structure (isolated mutation,
-externally-evaluated acceptance, persisted history) from this lineage.
+The design space of LLM-guided artifact optimization admits a spectrum of framework philosophies.
+At one end are minimalist scaffolds, exemplified by Karpathy's \texttt{autoresearch}~\cite{karpathy2025autoresearch}, that delegate almost all decision-making to the coding agent itself: the framework provides an edit--evaluate--commit loop, a single deterministic metric, and a human-maintained log of prior attempts, and the agent's intrinsic reasoning supplies acceptance judgment, search strategy, and memory of past experiments.
+This design bet is that as frontier LLMs improve, elaborate scaffolding becomes overhead rather than value, and that a thin framework plus a capable agent is sufficient for optimization on problems with clean deterministic metrics such as the held-out training loss of a single-GPU nanochat run.
+\textsc{anneal} draws its core experiment-loop structure (isolated mutation, externally-evaluated acceptance, persisted history) from this lineage.
 
-\textsc{anneal} occupies a different corner of this design space, one in
-which the framework assumes responsibility for three decisions the agent
-would otherwise make implicitly: whether a candidate is genuinely better
-than its predecessor under stochastic evaluation, which search strategy
-to use when the current one has stalled, and which prior experiments are
-relevant to the current hypothesis.
-These decisions are outside the reliable competence of a single-turn agent
-call, particularly when the evaluation signal is noisy (LLM-judge scores,
-small-sample benchmarks) and when the optimization trajectory spans dozens
-of experiments.
-The trade-off is more framework complexity in exchange for stronger
-correctness guarantees and better use of accumulated experiment history.
-The paper's three technical contributions (\cref{sec:results}) quantify
-the value of each of the three decisions the framework makes on the
-agent's behalf.
+\textsc{anneal} occupies a different corner of this design space, one in which the framework assumes responsibility for three decisions the agent would otherwise make implicitly: whether a candidate is genuinely better than its predecessor under stochastic evaluation, which search strategy to use when the current one has stalled, and which prior experiments are relevant to the current hypothesis.
+These decisions are outside the reliable competence of a single-turn agent call, particularly when the evaluation signal is noisy (LLM-judge scores, small-sample benchmarks) and when the optimization trajectory spans dozens of experiments.
+The trade-off is more framework complexity in exchange for stronger correctness guarantees and better use of accumulated experiment history.
+The paper's three technical contributions (\cref{sec:results}) quantify the value of each of the three decisions the framework makes on the agent's behalf.
 
-\cref{tab:related-comparison} summarizes the five closest prior systems
-along the axes that distinguish \textsc{anneal}: the form of acceptance
-decision, the search strategy layer, the knowledge accumulation
-mechanism, the evaluation modes supported, and the scope of artifacts
-optimized.
-No prior system addresses all five axes simultaneously, though many cover
-a subset.
+\cref{tab:related-comparison} summarizes the five closest prior systems along the axes that distinguish \textsc{anneal}: the form of acceptance decision, the search strategy layer, the knowledge accumulation mechanism, the evaluation modes supported, and the scope of artifacts optimized.
+No prior system addresses all five axes simultaneously, though many cover a subset.
 
 \begin{table*}[t]
   \centering
@@ -73,351 +47,156 @@ a subset.
   \end{tabular}
 \end{table*}
 
-We organize prior work into five areas: LLM-guided code optimization,
-LLM-guided prompt and reasoning optimization, evolutionary and metaheuristic
-methods with LLMs, agent memory and self-reflection, and statistical rigor
-in machine learning evaluation.
-For each, we identify what the approach contributes and where \textsc{anneal}
-differs or extends it.
+We organize prior work into five areas: LLM-guided code optimization, LLM-guided prompt and reasoning optimization, evolutionary and metaheuristic methods with LLMs, agent memory and self-reflection, and statistical rigor in machine learning evaluation.
+For each, we identify what the approach contributes and where \textsc{anneal} differs or extends it.
 
 \subsection{LLM-Guided Code Optimization}
 
-The premise that LLMs trained on code can serve as plausible mutation
-operators traces to early demonstrations that such models can produce
-functionally correct edits from natural-language
-instructions~\cite{chen2021codex}.
-Recent work has built on this by coupling LLM proposal with automated
-evaluators that close the loop from edit to signal.
+The premise that LLMs trained on code can serve as plausible mutation operators traces to early demonstrations that such models can produce functionally correct edits from natural-language instructions~\cite{chen2021codex}.
+Recent work has built on this by coupling LLM proposal with automated evaluators that close the loop from edit to signal.
 
 \paragraph{AlphaEvolve.}
-Novikov et al.~\cite{novikov2025alphaevolve} use an ensemble of LLMs within an
-evolutionary framework to discover algorithms for mathematical and computational
-problems.
-AlphaEvolve operates on code functions, using an island-based population model
-with a database of programs ranked by fitness.
-The system achieved state-of-the-art results on problems ranging from matrix
-multiplication to bin packing.
-\textsc{anneal} shares the evolutionary search intuition (population-based
-strategies and island migration are available search modes) but differs in three
-respects.
-First, \textsc{anneal} is domain-agnostic: it optimizes any text artifact, not
-only code functions, by decoupling mutation from evaluation through a shell
-command or LLM-judge interface.
-Second, \textsc{anneal} applies statistical hypothesis testing (Wilcoxon
-signed-rank with Holm--Bonferroni correction) rather than best-score selection,
-which is critical when evaluation is stochastic.
-Third, \textsc{anneal} accumulates structured knowledge across experiments via
-episodic memory and cross-target learning pools, whereas AlphaEvolve relies on
-the program database as implicit memory.
+Novikov et al.~\cite{novikov2025alphaevolve} use an ensemble of LLMs within an evolutionary framework to discover algorithms for mathematical and computational problems.
+AlphaEvolve operates on code functions, using an island-based population model with a database of programs ranked by fitness.
+The system achieved state-of-the-art results on problems ranging from matrix multiplication to bin packing.
+\textsc{anneal} shares the evolutionary search intuition (population-based strategies and island migration are available search modes) but differs in three respects.
+First, \textsc{anneal} is domain-agnostic: it optimizes any text artifact, not only code functions, by decoupling mutation from evaluation through a shell command or LLM-judge interface.
+Second, \textsc{anneal} applies statistical hypothesis testing (Wilcoxon signed-rank with Holm--Bonferroni correction) rather than best-score selection, which is critical when evaluation is stochastic.
+Third, \textsc{anneal} accumulates structured knowledge across experiments via episodic memory and cross-target learning pools, whereas AlphaEvolve relies on the program database as implicit memory.
 
 \paragraph{FunSearch.}
-Romera-Paredes et al.~\cite{romera2024funsearch} pair an LLM with an automated
-evaluator to search for novel mathematical functions, discovering new solutions
-to the cap set problem and online bin packing.
-FunSearch uses a best-shot selection strategy: the LLM generates many
-candidates, and the evaluator retains only the top-scoring outputs.
-This approach is effective when evaluation is cheap and deterministic but does
-not extend to stochastic evaluation, where a single score comparison is
-insufficient to distinguish signal from noise.
-\textsc{anneal} supports the same deterministic pipeline (generate, evaluate,
-keep the best) but adds paired statistical testing for stochastic settings,
-structured search strategies beyond best-shot, and a knowledge system that
-retains lessons from failed experiments rather than discarding them.
+Romera-Paredes et al.~\cite{romera2024funsearch} pair an LLM with an automated evaluator to search for novel mathematical functions, discovering new solutions to the cap set problem and online bin packing.
+FunSearch uses a best-shot selection strategy: the LLM generates many candidates, and the evaluator retains only the top-scoring outputs.
+This approach is effective when evaluation is cheap and deterministic but does not extend to stochastic evaluation, where a single score comparison is insufficient to distinguish signal from noise.
+\textsc{anneal} supports the same deterministic pipeline (generate, evaluate, keep the best) but adds paired statistical testing for stochastic settings, structured search strategies beyond best-shot, and a knowledge system that retains lessons from failed experiments rather than discarding them.
 
 \paragraph{Eureka.}
-Ma et al.~\cite{ma2023eureka} use LLMs as open-ended writers of reward
-functions for reinforcement learning in simulated robotics, iterating on
-the generated Python reward code against a deterministic task-success signal.
-Eureka demonstrates that LLMs can propose targeted edits to executable
-objective functions and that an outer loop over reward candidates improves
-downstream RL agent performance.
-The underlying loop (generate candidate code, evaluate via a deterministic
-metric, keep the best) is structurally similar to the deterministic branch
-of \textsc{anneal}'s evaluation pipeline; the difference is that Eureka
-is tightly scoped to reward-function synthesis for RL, while \textsc{anneal}
-is an artifact-agnostic framework whose evaluation function is user-defined.
+Ma et al.~\cite{ma2023eureka} use LLMs as open-ended writers of reward functions for reinforcement learning in simulated robotics, iterating on the generated Python reward code against a deterministic task-success signal.
+Eureka demonstrates that LLMs can propose targeted edits to executable objective functions and that an outer loop over reward candidates improves downstream RL agent performance.
+The underlying loop (generate candidate code, evaluate via a deterministic metric, keep the best) is structurally similar to the deterministic branch of \textsc{anneal}'s evaluation pipeline; the difference is that Eureka is tightly scoped to reward-function synthesis for RL, while \textsc{anneal} is an artifact-agnostic framework whose evaluation function is user-defined.
 
 \subsection{LLM-Guided Prompt and Reasoning Optimization}
 
-Prompt optimization has generated a rich body of work, driven by the sensitivity
-of LLM performance to prompt wording.
+Prompt optimization has generated a rich body of work, driven by the sensitivity of LLM performance to prompt wording.
 We review the most relevant systems.
 
 \paragraph{Promptbreeder.}
-Fernando et al.~\cite{fernando2024promptbreeder} evolve both task prompts and
-the mutation operators that generate them, creating a self-referential
-improvement loop.
-Promptbreeder's key insight is that the space of mutation operators is itself
-amenable to LLM-guided search.
-\textsc{anneal} captures a related idea through its strategy manifest, which
-decomposes the mutation approach into named components and evolves the weakest
-component when progress stalls, and through the policy agent, which continuously
-rewrites mutation instructions based on failure patterns.
-Unlike Promptbreeder, \textsc{anneal} applies statistical testing to accept/reject
-decisions and provides multiple search strategies rather than relying on a single
-evolutionary scheme.
+Fernando et al.~\cite{fernando2024promptbreeder} evolve both task prompts and the mutation operators that generate them, creating a self-referential improvement loop.
+Promptbreeder's key insight is that the space of mutation operators is itself amenable to LLM-guided search.
+\textsc{anneal} captures a related idea through its strategy manifest, which decomposes the mutation approach into named components and evolves the weakest component when progress stalls, and through the policy agent, which continuously rewrites mutation instructions based on failure patterns.
+Unlike Promptbreeder, \textsc{anneal} applies statistical testing to accept/reject decisions and provides multiple search strategies rather than relying on a single evolutionary scheme.
 
 \paragraph{DSPy.}
-Khattab et al.~\cite{khattab2024dspy} introduce a programming framework that
-compiles declarative language model pipelines into optimized prompts and
-fine-tuning data.
-DSPy's optimizers (BootstrapFewShot, MIPRO) search over demonstrations and
-instructions using teleprompter abstractions.
-DSPy focuses on prompt pipeline compilation rather than general artifact
-optimization, and its optimizers compare candidates by aggregate score without
-hypothesis testing.
-\textsc{anneal} addresses a broader scope (any text artifact with any evaluation
-function) and uses the Wilcoxon test to control false-positive acceptance when
-scores are noisy.
+Khattab et al.~\cite{khattab2024dspy} introduce a programming framework that compiles declarative language model pipelines into optimized prompts and fine-tuning data.
+DSPy's optimizers (BootstrapFewShot, MIPRO) search over demonstrations and instructions using teleprompter abstractions.
+DSPy focuses on prompt pipeline compilation rather than general artifact optimization, and its optimizers compare candidates by aggregate score without hypothesis testing.
+\textsc{anneal} addresses a broader scope (any text artifact with any evaluation function) and uses the Wilcoxon test to control false-positive acceptance when scores are noisy.
 
 \paragraph{EvoPrompt.}
-Guo et al.~\cite{guo2023evoprompt} apply discrete evolutionary operators
-(genetic algorithm and differential evolution) to prompt optimization, treating
-prompts as individuals in a population.
-EvoPrompt demonstrates that evolutionary search outperforms greedy prompt
-editing on several benchmarks.
-\textsc{anneal} offers population-based search as one of several strategies and
-adds Thompson Sampling~\cite{thompson1933likelihood} to adaptively select among
-strategies, rather than committing to a single evolutionary algorithm.
+Guo et al.~\cite{guo2023evoprompt} apply discrete evolutionary operators (genetic algorithm and differential evolution) to prompt optimization, treating prompts as individuals in a population.
+EvoPrompt demonstrates that evolutionary search outperforms greedy prompt editing on several benchmarks.
+\textsc{anneal} offers population-based search as one of several strategies and adds Thompson Sampling~\cite{thompson1933likelihood} to adaptively select among strategies, rather than committing to a single evolutionary algorithm.
 
 \paragraph{OPRO.}
-Yang et al.~\cite{yang2024opro} frame prompt optimization as an optimization
-problem where an LLM generates new prompts given a history of (prompt, score)
-pairs.
-OPRO relies on the LLM's in-context learning to identify improving directions
-from the optimization trajectory.
-\textsc{anneal} similarly provides experiment history as context but structures
-this history through episodic memory with per-criterion feedback, failure
-taxonomy classification, and lineage tracking, rather than presenting raw
-(prompt, score) tuples.
+Yang et al.~\cite{yang2024opro} frame prompt optimization as an optimization problem where an LLM generates new prompts given a history of (prompt, score) pairs.
+OPRO relies on the LLM's in-context learning to identify improving directions from the optimization trajectory.
+\textsc{anneal} similarly provides experiment history as context but structures this history through episodic memory with per-criterion feedback, failure taxonomy classification, and lineage tracking, rather than presenting raw (prompt, score) tuples.
 
 \paragraph{APE.}
-Zhou et al.~\cite{zhou2023ape} automate prompt engineering by generating
-candidate instructions, scoring them, and selecting the best.
-APE uses a generate-and-filter approach without iterative refinement beyond
-resampling.
-\textsc{anneal} extends this with iterative mutation guided by structured
-feedback from prior experiments and statistical testing for candidate comparison.
+Zhou et al.~\cite{zhou2023ape} automate prompt engineering by generating candidate instructions, scoring them, and selecting the best.
+APE uses a generate-and-filter approach without iterative refinement beyond resampling.
+\textsc{anneal} extends this with iterative mutation guided by structured feedback from prior experiments and statistical testing for candidate comparison.
 
 \paragraph{ProTeGi.}
-Pryzant et al.~\cite{pryzant2023protegi} use textual gradients (natural
-language descriptions of how to improve a prompt, generated by an LLM given
-input-output error pairs) to guide prompt optimization.
+Pryzant et al.~\cite{pryzant2023protegi} use textual gradients (natural language descriptions of how to improve a prompt, generated by an LLM given input-output error pairs) to guide prompt optimization.
 The gradient metaphor provides directional feedback absent in random mutation.
-\textsc{anneal}'s two-phase mutation pipeline serves a similar function: a
-diagnosis step identifies the weakest evaluation criteria and their root causes
-before a targeted mutation step generates edits, providing structured direction
-without requiring the gradient abstraction.
-ProTeGi operates greedily; \textsc{anneal} provides multiple search strategies
-and statistical acceptance criteria.
+\textsc{anneal}'s two-phase mutation pipeline serves a similar function: a diagnosis step identifies the weakest evaluation criteria and their root causes before a targeted mutation step generates edits, providing structured direction without requiring the gradient abstraction.
+ProTeGi operates greedily; \textsc{anneal} provides multiple search strategies and statistical acceptance criteria.
 
 \paragraph{TextGrad.}
-Y\"uksekgonul et al.~\cite{yuksekgonul2024textgrad} formalize the textual
-gradient metaphor as a differentiable-style computation graph in which LLMs
-propagate natural-language feedback backward from a scalar loss through
-composed components.
-TextGrad extends ProTeGi's textual-gradient intuition to multi-component
-pipelines, treating each component's feedback as an analogue of a gradient
-update.
-\textsc{anneal}'s diagnosis--mutation split is complementary: where TextGrad
-generalizes gradient propagation through a computation graph, \textsc{anneal}
-operates on a single artifact but adds statistical acceptance testing on top
-of the resulting edits, ensuring that textual-gradient-style updates are not
-accepted when they fall within evaluation noise.
+Y\"uksekgonul et al.~\cite{yuksekgonul2024textgrad} formalize the textual gradient metaphor as a differentiable-style computation graph in which LLMs propagate natural-language feedback backward from a scalar loss through composed components.
+TextGrad extends ProTeGi's textual-gradient intuition to multi-component pipelines, treating each component's feedback as an analogue of a gradient update.
+\textsc{anneal}'s diagnosis--mutation split is complementary: where TextGrad generalizes gradient propagation through a computation graph, \textsc{anneal} operates on a single artifact but adds statistical acceptance testing on top of the resulting edits, ensuring that textual-gradient-style updates are not accepted when they fall within evaluation noise.
 
 \paragraph{Self-Refine.}
-Madaan et al.~\cite{madaan2023selfrefine} introduce a canonical iterative
-refinement loop in which a single LLM generates an output, critiques it, and
-revises it without any external training signal, showing consistent
-improvements across reasoning, code, and generation tasks.
-Self-Refine establishes that iterative self-critique is valuable even when
-the critic and generator are the same model.
-\textsc{anneal} generalizes this loop in two directions: the critic is an
-external evaluator rather than the LLM itself (removing the self-grading
-bias), and the accept/reject decision is made by a statistical test on
-paired evaluations rather than by the LLM's own judgment of whether a
-revision is an improvement.
+Madaan et al.~\cite{madaan2023selfrefine} introduce a canonical iterative refinement loop in which a single LLM generates an output, critiques it, and revises it without any external training signal, showing consistent improvements across reasoning, code, and generation tasks.
+Self-Refine establishes that iterative self-critique is valuable even when the critic and generator are the same model.
+\textsc{anneal} generalizes this loop in two directions: the critic is an external evaluator rather than the LLM itself (removing the self-grading bias), and the accept/reject decision is made by a statistical test on paired evaluations rather than by the LLM's own judgment of whether a revision is an improvement.
 
 \paragraph{Tree of Thoughts.}
-Yao et al.~\cite{yao2023tot} frame reasoning-time problem solving as
-deliberate search over a tree of intermediate reasoning states, using
-breadth-first or depth-first traversal with LLM-scored node evaluation.
-Tree of Thoughts operates at reasoning time within a single model call,
-producing a search over thought trajectories.
-\textsc{anneal} operates at the outer loop instead (search over artifact
-states across many model calls) but shares the intuition that structured
-search over a model's proposals outperforms greedy single-shot generation
-once the solution space has meaningful local optima.
+Yao et al.~\cite{yao2023tot} frame reasoning-time problem solving as deliberate search over a tree of intermediate reasoning states, using breadth-first or depth-first traversal with LLM-scored node evaluation.
+Tree of Thoughts operates at reasoning time within a single model call, producing a search over thought trajectories.
+\textsc{anneal} operates at the outer loop instead (search over artifact states across many model calls) but shares the intuition that structured search over a model's proposals outperforms greedy single-shot generation once the solution space has meaningful local optima.
 
 \subsection{Evolutionary and Metaheuristic Methods with LLMs}
 
 \paragraph{MAP-Elites.}
-Mouret and Clune~\cite{mouret2015mapelites} introduce MAP-Elites, a
-quality-diversity algorithm that maintains an archive of solutions spanning
-a discretized behavioral space, keeping the highest-performing solution per
-cell.
-\textsc{anneal} incorporates a MAP-Elites archive as part of its knowledge
-system, maintaining best solutions per behavioral region to preserve diversity
-and enable the agent to draw on qualitatively different past solutions.
+Mouret and Clune~\cite{mouret2015mapelites} introduce MAP-Elites, a quality-diversity algorithm that maintains an archive of solutions spanning a discretized behavioral space, keeping the highest-performing solution per cell.
+\textsc{anneal} incorporates a MAP-Elites archive as part of its knowledge system, maintaining best solutions per behavioral region to preserve diversity and enable the agent to draw on qualitatively different past solutions.
 
 \paragraph{Thompson Sampling.}
-Thompson Sampling~\cite{thompson1933likelihood} is a Bayesian approach to the
-multi-armed bandit problem: sample from the posterior distribution of each arm's
-reward and select the arm with the highest sample.
-Chapelle and Li~\cite{chapelle2011empirical} provide an empirical evaluation
-demonstrating its effectiveness relative to UCB and $\epsilon$-greedy
-strategies.
-\textsc{anneal} uses Thompson Sampling as a meta-strategy to select among search
-algorithms (greedy, simulated annealing, population-based) based on each
-algorithm's observed performance during the optimization run, treating strategy
-selection as a contextual bandit problem with Beta-distributed priors updated
-after each experiment.
+Thompson Sampling~\cite{thompson1933likelihood} is a Bayesian approach to the multi-armed bandit problem: sample from the posterior distribution of each arm's reward and select the arm with the highest sample.
+Chapelle and Li~\cite{chapelle2011empirical} provide an empirical evaluation demonstrating its effectiveness relative to UCB and $\epsilon$-greedy strategies.
+\textsc{anneal} uses Thompson Sampling as a meta-strategy to select among search algorithms (greedy, simulated annealing, population-based) based on each algorithm's observed performance during the optimization run, treating strategy selection as a contextual bandit problem with Beta-distributed priors updated after each experiment.
 
 \paragraph{Simulated annealing.}
-Kirkpatrick et al.~\cite{kirkpatrick1983sa} introduced simulated annealing,
-which accepts worse solutions with a probability that decreases as a temperature
-parameter cools.
-\textsc{anneal} implements simulated annealing with adaptive cooling and reheat:
-when the acceptance ratio drops below a target threshold, the temperature
-increases to restore exploration, preventing premature convergence.
+Kirkpatrick et al.~\cite{kirkpatrick1983sa} introduced simulated annealing, which accepts worse solutions with a probability that decreases as a temperature parameter cools.
+\textsc{anneal} implements simulated annealing with adaptive cooling and reheat: when the acceptance ratio drops below a target threshold, the temperature increases to restore exploration, preventing premature convergence.
 
 \paragraph{Evolution through Large Models (ELM).}
-Lehman et al.~\cite{lehman2023elm} propose using LLMs as the mutation operator
-in a genetic algorithm, replacing hand-crafted mutation rules with
-LLM-proposed edits to a seed program.
-ELM establishes that LLM-as-mutation-operator is a viable alternative to
-symbolic mutation in evolutionary program search.
-\textsc{anneal} adopts the same proposal mechanism (LLM-generated edits to
-a seed artifact) but places it inside a decision layer that applies
-statistical acceptance rather than fitness-based selection, and generalizes
-the target from programs to any text artifact.
+Lehman et al.~\cite{lehman2023elm} propose using LLMs as the mutation operator in a genetic algorithm, replacing hand-crafted mutation rules with LLM-proposed edits to a seed program.
+ELM establishes that LLM-as-mutation-operator is a viable alternative to symbolic mutation in evolutionary program search.
+\textsc{anneal} adopts the same proposal mechanism (LLM-generated edits to a seed artifact) but places it inside a decision layer that applies statistical acceptance rather than fitness-based selection, and generalizes the target from programs to any text artifact.
 
 \paragraph{LLaMEA.}
-van Stein and B\"ack~\cite{vanstein2024llamea} present an LLM-driven
-evolutionary algorithm for automatically generating metaheuristics,
-applying LLM mutation operators to metaheuristic code and evaluating the
-resulting algorithms on benchmark suites.
-LLaMEA demonstrates that the LLM-as-mutation approach scales from
-code-synthesis tasks to the generation of optimization algorithms
-themselves.
-\textsc{anneal} targets a different level: rather than generating new
-metaheuristics, it composes existing metaheuristic strategies (greedy,
-simulated annealing, population, Thompson Sampling meta-selection) into
-a decision layer over LLM-generated artifact edits.
+van Stein and B\"ack~\cite{vanstein2024llamea} present an LLM-driven evolutionary algorithm for automatically generating metaheuristics, applying LLM mutation operators to metaheuristic code and evaluating the resulting algorithms on benchmark suites.
+LLaMEA demonstrates that the LLM-as-mutation approach scales from code-synthesis tasks to the generation of optimization algorithms themselves.
+\textsc{anneal} targets a different level: rather than generating new metaheuristics, it composes existing metaheuristic strategies (greedy, simulated annealing, population, Thompson Sampling meta-selection) into a decision layer over LLM-generated artifact edits.
 
 \subsection{Agent Memory and Self-Reflection}
 
-A parallel line of work focuses on memory architectures that let LLM
-agents accumulate knowledge across interactions, trials, or episodes.
-These systems are relevant to \textsc{anneal}'s episodic memory and
-cross-target learning pool.
+A parallel line of work focuses on memory architectures that let LLM agents accumulate knowledge across interactions, trials, or episodes.
+These systems are relevant to \textsc{anneal}'s episodic memory and cross-target learning pool.
 
 \paragraph{Reflexion.}
-Shinn et al.~\cite{shinn2023reflexion} equip LLM agents with verbal
-self-reflection: after each trial, the agent produces a natural-language
-critique of its own failure, which is appended to the context window for
-subsequent trials.
-Reflexion shows substantial gains on decision-making and reasoning
-benchmarks from this lightweight memory mechanism.
-\textsc{anneal}'s episodic memory carries a similar intuition (past
-experiment outcomes inform future mutations) but extends it along two
-axes: lessons are structured (\texttt{what\_changed},
-\texttt{transferable\_insight}, \texttt{domain\_tags}) rather than
-free-form critiques, and retrieval is similarity-based (TF-IDF or sentence
-embeddings) rather than simply appending the full history.
-This lets the agent see only the past experiments relevant to its current
-hypothesis, rather than the entire trajectory.
+Shinn et al.~\cite{shinn2023reflexion} equip LLM agents with verbal self-reflection: after each trial, the agent produces a natural-language critique of its own failure, which is appended to the context window for subsequent trials.
+Reflexion shows substantial gains on decision-making and reasoning benchmarks from this lightweight memory mechanism.
+\textsc{anneal}'s episodic memory carries a similar intuition (past experiment outcomes inform future mutations) but extends it along two axes: lessons are structured (\texttt{what\_changed}, \texttt{transferable\_insight}, \texttt{domain\_tags}) rather than free-form critiques, and retrieval is similarity-based (TF-IDF or sentence embeddings) rather than simply appending the full history.
+This lets the agent see only the past experiments relevant to its current hypothesis, rather than the entire trajectory.
 
 \paragraph{Voyager.}
-Wang et al.~\cite{wang2023voyager} build an open-ended Minecraft agent
-whose central component is an incrementally-constructed skill library: as
-the agent solves tasks, it abstracts working solutions into reusable
-skills that are retrieved by semantic similarity for future tasks.
-The skill library serves as a persistent memory that survives across
-episodes.
-\textsc{anneal}'s learning pool plays an analogous role for optimization
-experiments: each kept mutation contributes a \texttt{Learning} to a
-pool that is retrieved for new experiments on the same target or related
-targets, with decay-adjusted impact and domain-aware relevance filtering.
+Wang et al.~\cite{wang2023voyager} build an open-ended Minecraft agent whose central component is an incrementally-constructed skill library: as the agent solves tasks, it abstracts working solutions into reusable skills that are retrieved by semantic similarity for future tasks.
+The skill library serves as a persistent memory that survives across episodes.
+\textsc{anneal}'s learning pool plays an analogous role for optimization experiments: each kept mutation contributes a \texttt{Learning} to a pool that is retrieved for new experiments on the same target or related targets, with decay-adjusted impact and domain-aware relevance filtering.
 
 \paragraph{MemGPT.}
-Packer et al.~\cite{packer2023memgpt} introduce a hierarchical memory
-architecture that treats the LLM's context window as managed working
-memory with explicit paging to and from long-term storage.
-MemGPT establishes that deliberate memory hierarchy (what to keep in
-context, what to swap out, how to retrieve) is itself a system-design
-problem rather than a property of the model.
-\textsc{anneal} adopts a similar stance for experiment history: the
-context-assembly layer decides which past experiments to inject into the
-mutation agent's prompt based on recency, similarity, and a cold-start
-policy, rather than naively including the full experiment log.
+Packer et al.~\cite{packer2023memgpt} introduce a hierarchical memory architecture that treats the LLM's context window as managed working memory with explicit paging to and from long-term storage.
+MemGPT establishes that deliberate memory hierarchy (what to keep in context, what to swap out, how to retrieve) is itself a system-design problem rather than a property of the model.
+\textsc{anneal} adopts a similar stance for experiment history: the context-assembly layer decides which past experiments to inject into the mutation agent's prompt based on recency, similarity, and a cold-start policy, rather than naively including the full experiment log.
 
 \subsection{Statistical Rigor in ML Evaluation}
 
 \paragraph{Hypothesis testing for NLP.}
-Dror et al.~\cite{dror2018hitchhiker} survey statistical significance testing
-in NLP and recommend the Wilcoxon signed-rank test for paired comparisons of
-system outputs, noting that parametric tests (paired $t$-test) assume normality
-that NLP metrics rarely satisfy.
-\textsc{anneal} implements this recommendation directly: stochastic evaluations
-produce paired score vectors (challenger and baseline evaluated on the same
-inputs), and the Wilcoxon signed-rank test~\cite{wilcoxon1945individual}
-determines whether the observed differences are statistically significant.
-When fewer than six paired samples are available, \textsc{anneal} falls back to
-a Cohen's $d$ effect-size threshold, requiring at least a medium effect
-($d > 0.5$) for acceptance.
+Dror et al.~\cite{dror2018hitchhiker} survey statistical significance testing in NLP and recommend the Wilcoxon signed-rank test for paired comparisons of system outputs, noting that parametric tests (paired $t$-test) assume normality that NLP metrics rarely satisfy.
+\textsc{anneal} implements this recommendation directly: stochastic evaluations produce paired score vectors (challenger and baseline evaluated on the same inputs), and the Wilcoxon signed-rank test~\cite{wilcoxon1945individual} determines whether the observed differences are statistically significant.
+When fewer than six paired samples are available, \textsc{anneal} falls back to a Cohen's $d$ effect-size threshold, requiring at least a medium effect ($d > 0.5$) for acceptance.
 
 \paragraph{Statistical power and variance in ML benchmarks.}
-Card et al.~\cite{card2020power} analyze the statistical power of common
-NLP benchmarks and find that many published comparisons are underpowered,
-with effect sizes small enough that reported significant differences may
-not replicate.
-Bouthillier et al.~\cite{bouthillier2021variance} complement this analysis
-by showing that variance in machine-learning benchmark results is
-substantial and comes from multiple sources (data order, initialization,
-hardware non-determinism), and propose that ML evaluation should report
-paired variance estimates rather than single-run numbers.
-These findings motivate \textsc{anneal}'s paired-seed evaluation protocol
-and its use of variance-aware statistical tests at the accept/reject
-boundary of every experiment, rather than only at a single final
-comparison.
+Card et al.~\cite{card2020power} analyze the statistical power of common NLP benchmarks and find that many published comparisons are underpowered, with effect sizes small enough that reported significant differences may not replicate.
+Bouthillier et al.~\cite{bouthillier2021variance} complement this analysis by showing that variance in machine-learning benchmark results is substantial and comes from multiple sources (data order, initialization, hardware non-determinism), and propose that ML evaluation should report paired variance estimates rather than single-run numbers.
+These findings motivate \textsc{anneal}'s paired-seed evaluation protocol and its use of variance-aware statistical tests at the accept/reject boundary of every experiment, rather than only at a single final comparison.
 
 \paragraph{Multiple comparison correction.}
-Holm~\cite{holm1979simple} proposes a sequentially rejective procedure that
-controls the family-wise error rate without the conservatism of the Bonferroni
-correction.
-In \textsc{anneal}, each experiment within a consolidation window constitutes a
-hypothesis test; the Holm--Bonferroni adjustment divides the significance level
-$\alpha$ by the number of remaining comparisons in the window, reducing the
-false-positive rate for sequential testing.
-We validate the magnitude of this reduction on a synthetic null distribution in
-\cref{sec:gate-false-positives}.
+Holm~\cite{holm1979simple} proposes a sequentially rejective procedure that controls the family-wise error rate without the conservatism of the Bonferroni correction.
+In \textsc{anneal}, each experiment within a consolidation window constitutes a hypothesis test; the Holm--Bonferroni adjustment divides the significance level $\alpha$ by the number of remaining comparisons in the window, reducing the false-positive rate for sequential testing.
+We validate the magnitude of this reduction on a synthetic null distribution in \cref{sec:gate-false-positives}.
 
 \paragraph{Bootstrap confidence intervals.}
-Efron and Tibshirani~\cite{efron1994bootstrap} introduce the bootstrap as a
-general-purpose resampling method for estimating the sampling distribution
-of a statistic.
-\textsc{anneal} uses the bias-corrected and accelerated (BCa) bootstrap with
-10{,}000 resamples to produce confidence intervals on Cohen's $d$
-(\cref{sec:stat-design}) and on aggregate stochastic-evaluation scores
-(\cref{sec:eval-pipeline}), with deterministic seeding derived from the
-score vector so that bootstrap results are reproducible across runs.
+Efron and Tibshirani~\cite{efron1994bootstrap} introduce the bootstrap as a general-purpose resampling method for estimating the sampling distribution of a statistic.
+\textsc{anneal} uses the bias-corrected and accelerated (BCa) bootstrap with 10{,}000 resamples to produce confidence intervals on Cohen's $d$ (\cref{sec:stat-design}) and on aggregate stochastic-evaluation scores (\cref{sec:eval-pipeline}), with deterministic seeding derived from the score vector so that bootstrap results are reproducible across runs.
 
 \paragraph{Bradley--Terry scoring and LLM-as-judge calibration.}
-Bradley and Terry~\cite{bradley1952rank} propose a paired-comparison model where
-each item has a latent strength parameter estimated from pairwise win/loss data.
-\textsc{anneal} uses Bradley--Terry scoring with position-bias cancellation to
-calibrate its LLM judge: when the number of evaluation votes is two or more,
-half are presented with criteria in forward order and half in reverse, and the
-resulting win rates are combined to estimate calibrated quality scores that
-cancel the position bias inherent in LLM evaluation~\cite{zheng2023judging}.
-This position-bias concern is well-established in recent LLM-as-judge
-work: Liu et al.~\cite{liu2023geval} report that GPT-4 as a judge shows
-measurable order effects and prompt sensitivity, and that calibration via
-chain-of-thought and probability-weighted scoring yields better alignment
-with human judgments than raw preference counts.
-\textsc{anneal}'s Bradley--Terry aggregator is the mechanism-level
-counterpart: rather than trusting raw vote counts, it computes a latent
-strength parameter under the paired-comparison model, which is more
-robust to the position-bias and binary-threshold artefacts that raw
-counting inherits.
+Bradley and Terry~\cite{bradley1952rank} propose a paired-comparison model where each item has a latent strength parameter estimated from pairwise win/loss data.
+\textsc{anneal} uses Bradley--Terry scoring with position-bias cancellation to calibrate its LLM judge: when the number of evaluation votes is two or more, half are presented with criteria in forward order and half in reverse, and the resulting win rates are combined to estimate calibrated quality scores that cancel the position bias inherent in LLM evaluation~\cite{zheng2023judging}.
+This position-bias concern is well-established in recent LLM-as-judge work: Liu et al.~\cite{liu2023geval} report that GPT-4 as a judge shows measurable order effects and prompt sensitivity, and that calibration via chain-of-thought and probability-weighted scoring yields better alignment with human judgments than raw preference counts.
+\textsc{anneal}'s Bradley--Terry aggregator is the mechanism-level counterpart: rather than trusting raw vote counts, it computes a latent strength parameter under the paired-comparison model, which is more robust to the position-bias and binary-threshold artefacts that raw counting inherits.

--- a/paper/sections/related_work.tex
+++ b/paper/sections/related_work.tex
@@ -1,3 +1,4 @@
+% !TEX root = ../main.tex
 \section{Related Work}
 \label{sec:related_work}
 

--- a/paper/sections/related_work.tex
+++ b/paper/sections/related_work.tex
@@ -13,8 +13,8 @@ This design bet is that as frontier LLMs improve, elaborate scaffolding
 becomes overhead rather than value, and that a thin framework plus a capable
 agent is sufficient for optimization on problems with clean deterministic
 metrics such as the held-out training loss of a single-GPU nanochat run.
-\textsc{anneal} draws its core experiment-loop structure---isolated mutation,
-externally-evaluated acceptance, persisted history---from this lineage.
+\textsc{anneal} draws its core experiment-loop structure (isolated mutation,
+externally-evaluated acceptance, persisted history) from this lineage.
 
 \textsc{anneal} occupies a different corner of this design space, one in
 which the framework assumes responsibility for three decisions the agent
@@ -43,13 +43,13 @@ a subset.
 \begin{table*}[t]
   \centering
   \caption{Comparison of \textsc{anneal} with the closest prior systems along
-  five axes. \textbf{Accept:} how accept/reject decisions are made---point-score
+  five axes. \textbf{Accept:} how accept/reject decisions are made: point-score
   (P), best-shot selection (B), statistical test (S). \textbf{Search:} search
-  strategy layer---greedy (G), evolutionary (E), bandit meta-strategy (M),
+  strategy layer: greedy (G), evolutionary (E), bandit meta-strategy (M),
   reasoning-time search (R). \textbf{Memory:} knowledge accumulation
-  mechanism---none (---), program database (D), verbal self-reflection (V),
+  mechanism: none (---), program database (D), verbal self-reflection (V),
   structured retrieval (S). \textbf{Eval modes:} deterministic (D),
-  stochastic / LLM-judge (L). \textbf{Scope:} artifact type---code functions
+  stochastic / LLM-judge (L). \textbf{Scope:} artifact type: code functions
   (C), prompts (P), reasoning traces (R), any text artifact (A).}
   \label{tab:related-comparison}
   \small
@@ -97,8 +97,8 @@ AlphaEvolve operates on code functions, using an island-based population model
 with a database of programs ranked by fitness.
 The system achieved state-of-the-art results on problems ranging from matrix
 multiplication to bin packing.
-\textsc{anneal} shares the evolutionary search intuition---population-based
-strategies and island migration are available search modes---but differs in three
+\textsc{anneal} shares the evolutionary search intuition (population-based
+strategies and island migration are available search modes) but differs in three
 respects.
 First, \textsc{anneal} is domain-agnostic: it optimizes any text artifact, not
 only code functions, by decoupling mutation from evaluation through a shell
@@ -119,8 +119,8 @@ candidates, and the evaluator retains only the top-scoring outputs.
 This approach is effective when evaluation is cheap and deterministic but does
 not extend to stochastic evaluation, where a single score comparison is
 insufficient to distinguish signal from noise.
-\textsc{anneal} supports the same deterministic pipeline---generate, evaluate,
-keep the best---but adds paired statistical testing for stochastic settings,
+\textsc{anneal} supports the same deterministic pipeline (generate, evaluate,
+keep the best) but adds paired statistical testing for stochastic settings,
 structured search strategies beyond best-shot, and a knowledge system that
 retains lessons from failed experiments rather than discarding them.
 
@@ -131,8 +131,8 @@ the generated Python reward code against a deterministic task-success signal.
 Eureka demonstrates that LLMs can propose targeted edits to executable
 objective functions and that an outer loop over reward candidates improves
 downstream RL agent performance.
-The underlying loop---generate candidate code, evaluate via a deterministic
-metric, keep the best---is structurally similar to the deterministic branch
+The underlying loop (generate candidate code, evaluate via a deterministic
+metric, keep the best) is structurally similar to the deterministic branch
 of \textsc{anneal}'s evaluation pipeline; the difference is that Eureka
 is tightly scoped to reward-function synthesis for RL, while \textsc{anneal}
 is an artifact-agnostic framework whose evaluation function is user-defined.
@@ -166,8 +166,8 @@ instructions using teleprompter abstractions.
 DSPy focuses on prompt pipeline compilation rather than general artifact
 optimization, and its optimizers compare candidates by aggregate score without
 hypothesis testing.
-\textsc{anneal} addresses a broader scope---any text artifact with any evaluation
-function---and uses the Wilcoxon test to control false-positive acceptance when
+\textsc{anneal} addresses a broader scope (any text artifact with any evaluation
+function) and uses the Wilcoxon test to control false-positive acceptance when
 scores are noisy.
 
 \paragraph{EvoPrompt.}
@@ -188,7 +188,7 @@ OPRO relies on the LLM's in-context learning to identify improving directions
 from the optimization trajectory.
 \textsc{anneal} similarly provides experiment history as context but structures
 this history through episodic memory with per-criterion feedback, failure
-taxonomy classification, and lineage tracking---rather than presenting raw
+taxonomy classification, and lineage tracking, rather than presenting raw
 (prompt, score) tuples.
 
 \paragraph{APE.}
@@ -200,9 +200,9 @@ resampling.
 feedback from prior experiments and statistical testing for candidate comparison.
 
 \paragraph{ProTeGi.}
-Pryzant et al.~\cite{pryzant2023protegi} use textual gradients---natural
+Pryzant et al.~\cite{pryzant2023protegi} use textual gradients (natural
 language descriptions of how to improve a prompt, generated by an LLM given
-input-output error pairs---to guide prompt optimization.
+input-output error pairs) to guide prompt optimization.
 The gradient metaphor provides directional feedback absent in random mutation.
 \textsc{anneal}'s two-phase mutation pipeline serves a similar function: a
 diagnosis step identifies the weakest evaluation criteria and their root causes
@@ -244,8 +244,8 @@ deliberate search over a tree of intermediate reasoning states, using
 breadth-first or depth-first traversal with LLM-scored node evaluation.
 Tree of Thoughts operates at reasoning time within a single model call,
 producing a search over thought trajectories.
-\textsc{anneal} operates at the outer loop instead---search over artifact
-states across many model calls---but shares the intuition that structured
+\textsc{anneal} operates at the outer loop instead (search over artifact
+states across many model calls) but shares the intuition that structured
 search over a model's proposals outperforms greedy single-shot generation
 once the solution space has meaningful local optima.
 
@@ -319,8 +319,8 @@ critique of its own failure, which is appended to the context window for
 subsequent trials.
 Reflexion shows substantial gains on decision-making and reasoning
 benchmarks from this lightweight memory mechanism.
-\textsc{anneal}'s episodic memory carries a similar intuition---past
-experiment outcomes inform future mutations---but extends it along two
+\textsc{anneal}'s episodic memory carries a similar intuition (past
+experiment outcomes inform future mutations) but extends it along two
 axes: lessons are structured (\texttt{what\_changed},
 \texttt{transferable\_insight}, \texttt{domain\_tags}) rather than
 free-form critiques, and retrieval is similarity-based (TF-IDF or sentence
@@ -344,8 +344,8 @@ targets, with decay-adjusted impact and domain-aware relevance filtering.
 Packer et al.~\cite{packer2023memgpt} introduce a hierarchical memory
 architecture that treats the LLM's context window as managed working
 memory with explicit paging to and from long-term storage.
-MemGPT establishes that deliberate memory hierarchy---what to keep in
-context, what to swap out, how to retrieve---is itself a system-design
+MemGPT establishes that deliberate memory hierarchy (what to keep in
+context, what to swap out, how to retrieve) is itself a system-design
 problem rather than a property of the model.
 \textsc{anneal} adopts a similar stance for experiment history: the
 context-assembly layer decides which past experiments to inject into the

--- a/paper/sections/results.tex
+++ b/paper/sections/results.tex
@@ -1,4 +1,3 @@
-% !TEX root = ../main.tex
 \section{Empirical Validation}
 \label{sec:results}
 

--- a/paper/sections/results.tex
+++ b/paper/sections/results.tex
@@ -1,3 +1,4 @@
+% !TEX root = ../main.tex
 \section{Empirical Validation}
 \label{sec:results}
 

--- a/paper/sections/results.tex
+++ b/paper/sections/results.tex
@@ -3,7 +3,7 @@
 \label{sec:results}
 
 We evaluate \textsc{anneal} along two complementary axes.
-\Cref{sec:gate-false-positives,sec:gate-sa,sec:gate-retrieval} validate the three central mechanisms---statistical acceptance, adaptive metaheuristic search, and structured knowledge retrieval---in isolation on synthetic tasks where the ground truth is known analytically.
+\Cref{sec:gate-false-positives,sec:gate-sa,sec:gate-retrieval} validate the three central mechanisms (statistical acceptance, adaptive metaheuristic search, and structured knowledge retrieval) in isolation on synthetic tasks where the ground truth is known analytically.
 \Cref{sec:end-to-end} reports an end-to-end comparison of four nested configurations across the five-target benchmark suite of \cref{sec:benchmark-suite}, using the multi-seed paired protocol of \cref{sec:stat-design}.
 The mechanism-level baselines in this section are method-specific (uncorrected sequential testing, fixed-schedule simulated annealing, Jaccard set similarity) and do not exercise the raw, greedy, control, and treatment vocabulary, which is reserved for the end-to-end study.
 Each gate benchmark is evaluated against a quantitative threshold defined before the experiment was run.
@@ -215,7 +215,7 @@ The treatment-versus-control effect sizes are small to large across targets ($d 
 
 \paragraph{Why this is the framework working as designed.}
 The non-significance of treatment-versus-control after correction is the framework's statistical acceptance discipline applied to itself.
-A point-score comparison of the same data would report ``treatment beats control on 5/5 targets'' as a victory; the same comparison run with the engine's own machinery---paired Wilcoxon, multiplicity correction across the five-target family---declines to make that claim at $n = 5$ paired seeds.
+A point-score comparison of the same data would report ``treatment beats control on 5/5 targets'' as a victory; the same comparison run with the engine's own machinery (paired Wilcoxon, multiplicity correction across the five-target family) declines to make that claim at $n = 5$ paired seeds.
 The Wilcoxon test's minimum attainable $p$-value at $n = 5$ is $1/2^5 = 0.03125$ for a one-sided test and $0.0625$ for a two-sided test, so even a perfect 5/0 sign sweep within a target sits just above the per-comparison threshold and well above the corrected one.
 This is the same conservatism that \cref{sec:gate-false-positives} validated on a synthetic null: the multiplicity correction does not produce false-positive headlines, and at this seed count it requires effect sizes well into Cohen's-large territory or perfect directional consistency in conjunction with a less aggressive correction to reject the null.
 The directional pattern across targets and the two near-significant B3/B5 greedy-versus-treatment comparisons both indicate where a higher-powered replication would push the result.
@@ -259,7 +259,7 @@ The seed artifact is a single-file CRUD endpoint of $\sim 60$ lines: validation 
 Under the deterministic composite scorer (correctness via a hidden test suite, plus lint compliance scaled by violation count), this artifact scores $\bar{x}_{\text{raw}} = 0.174$ across the five seeds.
 On the first accepted treatment mutation of seed 1, the agent rewrote the file end-to-end: typed pydantic-style request models, explicit email-format and age-range validation with \texttt{422} responses, structured exception handling with distinct status codes for validation versus internal errors, and ISO-formatted timestamps via \texttt{datetime.isoformat}.
 The composite score moved from $0.435$ at the seed's pre-experiment baseline to $0.9$ after the mutation, a single-step jump that the framework's statistical-acceptance layer then preserved as the reference baseline for subsequent experiments.
-This pattern---a large early jump from the raw artifact, followed by smaller incremental refinements that the multiplicity-corrected acceptance layer admits selectively---is consistent with the per-target descriptive statistics in \cref{tab:e2e-final-scores}.
+This pattern (a large early jump from the raw artifact, followed by smaller incremental refinements that the multiplicity-corrected acceptance layer admits selectively) is consistent with the per-target descriptive statistics in \cref{tab:e2e-final-scores}.
 The full per-experiment trajectories for every seed and configuration are shipped as JSONL in \texttt{benchmarks/raw\_results\_seeds1-5/}.
 
 \subsubsection{Layer-by-Layer Marginal Effects}
@@ -291,7 +291,7 @@ Reading down the chain isolates the marginal contribution of each layer of \text
 The raw $\to$ greedy column is reported only for targets where the raw mean is non-zero, since percentage change from a zero baseline is undefined.
 On the four targets where the greedy $\to$ control transition is well-defined alongside the rest of the chain, the statistical-acceptance layer adds value above greedy on three of them; the regressions on B2 and B4 are small in absolute terms and within the seed-level standard deviation, consistent with sampling noise at $n = 5$.
 The control $\to$ treatment transition is positive on all five targets, ranging from $+3.5\%$ to $+44.5\%$.
-This is the cleanest empirical evidence in the suite that the four enhancement tracks of \cref{sec:enhancements}---representation, search, knowledge, evaluation---contribute incrementally above a hybrid-search engine without those tracks, even when the additional contribution does not survive multiplicity correction at the seed count run.
+This is the cleanest empirical evidence in the suite that the four enhancement tracks of \cref{sec:enhancements} (representation, search, knowledge, evaluation) contribute incrementally above a hybrid-search engine without those tracks, even when the additional contribution does not survive multiplicity correction at the seed count run.
 
 % ==================================================================
 \subsection{Synthesis}

--- a/paper/sections/system_design.tex
+++ b/paper/sections/system_design.tex
@@ -157,6 +157,7 @@ A divergence exceeding 10\% triggers a warning; 25\% triggers a critical alert, 
 \begin{figure}[t]
     \centering
     \includegraphics[width=\columnwidth]{figures/architecture.png}
+    \Description{A diagram showing the anneal system architecture. A user registers a target as an Artifact-Eval-Agent triplet. The engine uses a git worktree, a mutation agent, and scope constraints to evaluate and commit accepted mutations or reset rejected ones.}
     \caption{\textsc{anneal} system architecture. The user registers a target as an Artifact--Eval--Agent triplet. The engine creates an isolated git worktree, invokes the mutation agent, enforces scope constraints, evaluates the mutated artifact, and applies a statistical acceptance test. Accepted mutations are committed; rejected mutations are reset.}
     \label{fig:architecture}
 \end{figure}

--- a/paper/sections/system_design.tex
+++ b/paper/sections/system_design.tex
@@ -12,7 +12,7 @@ Every optimization target in \textsc{anneal} is registered as a triplet of decla
 \begin{enumerate}
     \item \textbf{Artifact} (\texttt{artifact\_paths}). One or more text files the agent is permitted to mutate: system prompts, source code, configuration files, or any other UTF-8 content tracked by git. The set of editable paths is declared in \texttt{scope.yaml} and validated at registration time by the \texttt{Registry} class. The engine imposes no constraints on file format or domain semantics.
 
-    \item \textbf{Eval} (\texttt{EvalConfig}). A scoring function that maps an artifact state to a scalar signal. Two modes are supported: \emph{deterministic}, where a shell command produces a numeric score (e.g., \texttt{pytest --tb=no | parse\_score.sh}), and \emph{stochastic}, where an LLM judge scores generated samples against binary criteria (\cref{sec:eval-pipeline}). The eval definition is immutable once registered---\texttt{scope.yaml}, \texttt{metrics.yaml}, and \texttt{eval\_criteria.toml} are required entries in the \texttt{immutable} list, preventing the agent from influencing its own scoring.
+    \item \textbf{Eval} (\texttt{EvalConfig}). A scoring function that maps an artifact state to a scalar signal. Two modes are supported: \emph{deterministic}, where a shell command produces a numeric score (e.g., \texttt{pytest --tb=no | parse\_score.sh}), and \emph{stochastic}, where an LLM judge scores generated samples against binary criteria (\cref{sec:eval-pipeline}). The eval definition is immutable once registered: \texttt{scope.yaml}, \texttt{metrics.yaml}, and \texttt{eval\_criteria.toml} are required entries in the \texttt{immutable} list, preventing the agent from influencing its own scoring.
 
     \item \textbf{Agent} (\texttt{AgentConfig} + \texttt{program.md}). An LLM that proposes mutations, restricted to file-edit tools operating within the editable scope. The agent receives the current artifact content, experiment history, and mutation instructions (\texttt{program.md}), but never sees the eval command, criteria definitions, or scoring logic. \texttt{AgentInvoker} dispatches to either a Claude Code subprocess (which writes files directly to disk) or a direct API call depending on \texttt{AgentConfig.mode}.
 \end{enumerate}
@@ -109,7 +109,7 @@ The aggregate score across all samples is accompanied by bootstrap confidence in
 % ------------------------------------------------------------------
 \subsection{Statistical Comparison}\label{sec:stat-comparison}
 
-Accept/reject decisions for stochastic evaluations use the Wilcoxon signed-rank test (ADR-002), implemented in \texttt{Greedy\allowbreak{}Search.\allowbreak{}\_stochastic\allowbreak{}\_compare} (\texttt{anneal/\allowbreak{}engine/\allowbreak{}search.py}). The test is non-parametric and valid for binary and small-sample paired data---the common case in prompt optimization where sample counts range from 6 to 20.
+Accept/reject decisions for stochastic evaluations use the Wilcoxon signed-rank test (ADR-002), implemented in \texttt{Greedy\allowbreak{}Search.\allowbreak{}\_stochastic\allowbreak{}\_compare} (\texttt{anneal/\allowbreak{}engine/\allowbreak{}search.py}). The test is non-parametric and valid for binary and small-sample paired data, the common case in prompt optimization where sample counts range from 6 to 20.
 
 The comparison procedure is:
 \begin{enumerate}

--- a/paper/sections/system_design.tex
+++ b/paper/sections/system_design.tex
@@ -1,3 +1,4 @@
+% !TEX root = ../main.tex
 \section{System Design}\label{sec:system-design}
 
 \textsc{anneal}'s architecture is organized around three invariants: the optimization target is always a text file in a git repository, the evaluation signal is always an external process the agent cannot influence, and mutations are always isolated in a dedicated worktree that the user's working tree never observes.

--- a/paper/sections/system_design.tex
+++ b/paper/sections/system_design.tex
@@ -10,11 +10,20 @@ This section describes the core abstractions, execution environment, safety mech
 Every optimization target in \textsc{anneal} is registered as a triplet of declarative specifications (ADR-003):
 
 \begin{enumerate}
-    \item \textbf{Artifact} (\texttt{artifact\_paths}). One or more text files the agent is permitted to mutate: system prompts, source code, configuration files, or any other UTF-8 content tracked by git. The set of editable paths is declared in \texttt{scope.yaml} and validated at registration time by the \texttt{Registry} class. The engine imposes no constraints on file format or domain semantics.
+    \item \textbf{Artifact} (\texttt{artifact\_paths}).
+    One or more text files the agent is permitted to mutate: system prompts, source code, configuration files, or any other UTF-8 content tracked by git.
+    The set of editable paths is declared in \texttt{scope.yaml} and validated at registration time by the \texttt{Registry} class.
+    The engine imposes no constraints on file format or domain semantics.
 
-    \item \textbf{Eval} (\texttt{EvalConfig}). A scoring function that maps an artifact state to a scalar signal. Two modes are supported: \emph{deterministic}, where a shell command produces a numeric score (e.g., \texttt{pytest --tb=no | parse\_score.sh}), and \emph{stochastic}, where an LLM judge scores generated samples against binary criteria (\cref{sec:eval-pipeline}). The eval definition is immutable once registered: \texttt{scope.yaml}, \texttt{metrics.yaml}, and \texttt{eval\_criteria.toml} are required entries in the \texttt{immutable} list, preventing the agent from influencing its own scoring.
+    \item \textbf{Eval} (\texttt{EvalConfig}).
+    A scoring function that maps an artifact state to a scalar signal.
+    Two modes are supported: \emph{deterministic}, where a shell command produces a numeric score (e.g., \texttt{pytest --tb=no | parse\_score.sh}), and \emph{stochastic}, where an LLM judge scores generated samples against binary criteria (\cref{sec:eval-pipeline}).
+    The eval definition is immutable once registered: \texttt{scope.yaml}, \texttt{metrics.yaml}, and \texttt{eval\_criteria.toml} are required entries in the \texttt{immutable} list, preventing the agent from influencing its own scoring.
 
-    \item \textbf{Agent} (\texttt{AgentConfig} + \texttt{program.md}). An LLM that proposes mutations, restricted to file-edit tools operating within the editable scope. The agent receives the current artifact content, experiment history, and mutation instructions (\texttt{program.md}), but never sees the eval command, criteria definitions, or scoring logic. \texttt{AgentInvoker} dispatches to either a Claude Code subprocess (which writes files directly to disk) or a direct API call depending on \texttt{AgentConfig.mode}.
+    \item \textbf{Agent} (\texttt{AgentConfig} + \texttt{program.md}).
+    An LLM that proposes mutations, restricted to file-edit tools operating within the editable scope.
+    The agent receives the current artifact content, experiment history, and mutation instructions (\texttt{program.md}), but never sees the eval command, criteria definitions, or scoring logic.
+    \texttt{AgentInvoker} dispatches to either a Claude Code subprocess (which writes files directly to disk) or a direct API call depending on \texttt{AgentConfig.mode}.
 \end{enumerate}
 
 The triplet is the schema of \texttt{Optimization\allowbreak{}Target} (\texttt{anneal/\allowbreak{}engine/\allowbreak{}types.py}), persisted to \texttt{.anneal/\allowbreak{}config.toml} via the \texttt{Registry} class.
@@ -23,7 +32,10 @@ This design makes the engine domain-agnostic: adding a new optimization target r
 % ------------------------------------------------------------------
 \subsection{Execution Environment: Git Worktree Isolation}\label{sec:worktree}
 
-A central design requirement is that the optimization loop never touches the user's working tree. \textsc{anneal} achieves this through git worktrees (ADR-001). Each registered target receives a dedicated worktree at \texttt{.anneal/worktrees/<target-id>} on a branch named \texttt{anneal/<target-id>}. The \texttt{GitEnvironment} class (\texttt{anneal/engine/environment.py}) manages all worktree lifecycle operations: creation with stale-reference pruning, commit, reset, diff capture, and removal.
+A central design requirement is that the optimization loop never touches the user's working tree.
+\textsc{anneal} achieves this through git worktrees (ADR-001).
+Each registered target receives a dedicated worktree at \texttt{.anneal/worktrees/<target-id>} on a branch named \texttt{anneal/<target-id>}.
+The \texttt{GitEnvironment} class (\texttt{anneal/engine/environment.py}) manages all worktree lifecycle operations: creation with stale-reference pruning, commit, reset, diff capture, and removal.
 
 The experiment cycle within the worktree proceeds as follows; \cref{alg:experiment-loop} gives the full pseudocode.
 
@@ -68,18 +80,24 @@ The experiment cycle within the worktree proceeds as follows; \cref{alg:experime
 \end{algorithmic}
 \end{algorithm}
 
-The system never uses \texttt{git stash}. The only snapshot and restore mechanism is commit and hard reset. Every accepted mutation is a real git commit, making the full optimization history inspectable with standard git tooling. Garbage collection is configured to retain unreachable commits (\texttt{gc.reflogExpire=never}), preserving the complete experiment lineage.
+The system never uses \texttt{git stash}.
+The only snapshot and restore mechanism is commit and hard reset.
+Every accepted mutation is a real git commit, making the full optimization history inspectable with standard git tooling.
+Garbage collection is configured to retain unreachable commits (\texttt{gc.reflogExpire=never}), preserving the complete experiment lineage.
 
 For in-place targets where worktree isolation is not feasible, a \texttt{File\allowbreak{}Backup\allowbreak{}Environment} copies artifact files to \texttt{.anneal/\allowbreak{}backups/\allowbreak{}<target-id>/} before each experiment, restoring them on discard.
 
 % ------------------------------------------------------------------
 \subsection{Scope Enforcement}\label{sec:scope}
 
-Scope enforcement prevents the agent from modifying files outside its declared editable set, gaming evaluation definitions, or contaminating sibling targets' configurations (ADR-004). The enforcement operates in two stages.
+Scope enforcement prevents the agent from modifying files outside its declared editable set, gaming evaluation definitions, or contaminating sibling targets' configurations (ADR-004).
+The enforcement operates in two stages.
 
-\paragraph{Registration-time validation.} The \texttt{validate\allowbreak{}\_\allowbreak{}scope} function (\texttt{anneal/\allowbreak{}engine/\allowbreak{}scope.py}) checks that \texttt{scope.yaml} satisfies required invariants: \texttt{scope.yaml} and \texttt{metrics.yaml} appear in \texttt{immutable}; stochastic targets additionally require \texttt{eval\allowbreak{}\_criteria.toml} in \texttt{immutable}; no path appears in both \texttt{editable} and \texttt{immutable}; sibling targets' configuration paths are not declared as editable.
+\paragraph{Registration-time validation.}
+The \texttt{validate\allowbreak{}\_\allowbreak{}scope} function (\texttt{anneal/\allowbreak{}engine/\allowbreak{}scope.py}) checks that \texttt{scope.yaml} satisfies required invariants: \texttt{scope.yaml} and \texttt{metrics.yaml} appear in \texttt{immutable}; stochastic targets additionally require \texttt{eval\allowbreak{}\_criteria.toml} in \texttt{immutable}; no path appears in both \texttt{editable} and \texttt{immutable}; sibling targets' configuration paths are not declared as editable.
 
-\paragraph{Runtime post-write validation.} After each agent invocation, \texttt{enforce\_scope} inspects the output of \texttt{git status -{}-porcelain} and classifies every changed file:
+\paragraph{Runtime post-write validation.}
+After each agent invocation, \texttt{enforce\_scope} inspects the output of \texttt{git status -{}-porcelain} and classifies every changed file:
 \begin{itemize}
     \item Modified or added files (\texttt{M}, \texttt{A}, \texttt{??}): accepted if the path matches an \texttt{editable} entry (exact match, directory prefix, or glob pattern).
     \item Deleted files (\texttt{D}): accepted only if the path appears in both \texttt{editable} and \texttt{allowed\_deletions}.
@@ -87,16 +105,23 @@ Scope enforcement prevents the agent from modifying files outside its declared e
     \item Path traversal attempts (paths starting with \texttt{..} or absolute paths) are rejected unconditionally via \texttt{os.path.normpath} canonicalization.
 \end{itemize}
 
-Integrity is maintained by a SHA-256 hash of \texttt{scope.yaml} computed at registration time and verified at every experiment start. A hash mismatch raises \texttt{ScopeIntegrityError} and halts the run, requiring explicit re-registration.
+Integrity is maintained by a SHA-256 hash of \texttt{scope.yaml} computed at registration time and verified at every experiment start.
+A hash mismatch raises \texttt{ScopeIntegrityError} and halts the run, requiring explicit re-registration.
 
 % ------------------------------------------------------------------
 \subsection{Evaluation Pipeline}\label{sec:eval-pipeline}
 
-The \texttt{EvalEngine} class (\texttt{anneal/engine/eval.py}) dispatches evaluation based on \texttt{EvalConfig}. Two modes are supported.
+The \texttt{EvalEngine} class (\texttt{anneal/engine/eval.py}) dispatches evaluation based on \texttt{EvalConfig}.
+Two modes are supported.
 
-\paragraph{Deterministic evaluation.} A \texttt{run\_command} executes in the worktree (e.g., a test suite, a linter, a benchmark), and a \texttt{parse\_command} extracts a numeric score from its stdout. The \texttt{DeterministicEvaluator} supports retry on transient failures and flake detection via median-of-three runs.
+\paragraph{Deterministic evaluation.}
+A \texttt{run\_command} executes in the worktree (e.g., a test suite, a linter, a benchmark), and a \texttt{parse\_command} extracts a numeric score from its stdout.
+The \texttt{DeterministicEvaluator} supports retry on transient failures and flake detection via median-of-three runs.
 
-\paragraph{Stochastic evaluation.} The \texttt{StochasticEvaluator} generates $N$ samples from fixed test prompts using a generation agent, then scores each sample against $K$ binary criteria using a judge agent. Each criterion receives $V$ independent votes. To cancel position bias, votes are split between forward and reverse criterion orderings, and the per-criterion score is the mean across both orderings.
+\paragraph{Stochastic evaluation.}
+The \texttt{StochasticEvaluator} generates $N$ samples from fixed test prompts using a generation agent, then scores each sample against $K$ binary criteria using a judge agent.
+Each criterion receives $V$ independent votes.
+To cancel position bias, votes are split between forward and reverse criterion orderings, and the per-criterion score is the mean across both orderings.
 
 Two comparison modes are available for aggregating votes:
 \begin{itemize}
@@ -109,7 +134,8 @@ The aggregate score across all samples is accompanied by bootstrap confidence in
 % ------------------------------------------------------------------
 \subsection{Statistical Comparison}\label{sec:stat-comparison}
 
-Accept/reject decisions for stochastic evaluations use the Wilcoxon signed-rank test (ADR-002), implemented in \texttt{Greedy\allowbreak{}Search.\allowbreak{}\_stochastic\allowbreak{}\_compare} (\texttt{anneal/\allowbreak{}engine/\allowbreak{}search.py}). The test is non-parametric and valid for binary and small-sample paired data, the common case in prompt optimization where sample counts range from 6 to 20.
+Accept/reject decisions for stochastic evaluations use the Wilcoxon signed-rank test (ADR-002), implemented in \texttt{Greedy\allowbreak{}Search.\allowbreak{}\_stochastic\allowbreak{}\_compare} (\texttt{anneal/\allowbreak{}engine/\allowbreak{}search.py}).
+The test is non-parametric and valid for binary and small-sample paired data, the common case in prompt optimization where sample counts range from 6 to 20.
 
 The comparison procedure is:
 \begin{enumerate}
@@ -120,9 +146,11 @@ The comparison procedure is:
     \item Accept if $p < \alpha$, where $\alpha = 1 - \text{confidence}$ (default $0.05$).
 \end{enumerate}
 
-For long-running optimization, Holm--Bonferroni correction controls the family-wise error rate across sequential experiments. The adjusted threshold is $\alpha / (\text{window\_size} - \text{experiment\_index})$ within a rolling 50-experiment window, reducing false-positive acceptance at the cost of decreased sensitivity for later experiments.
+For long-running optimization, Holm--Bonferroni correction controls the family-wise error rate across sequential experiments.
+The adjusted threshold is $\alpha / (\text{window\_size} - \text{experiment\_index})$ within a rolling 50-experiment window, reducing false-positive acceptance at the cost of decreased sensitivity for later experiments.
 
-Held-out divergence detection runs stochastic evaluation against a separate set of held-out prompts at configurable intervals (\texttt{held\_out\_interval}). A divergence exceeding 10\% triggers a warning; 25\% triggers a critical alert, indicating potential overfitting to the test prompt distribution.
+Held-out divergence detection runs stochastic evaluation against a separate set of held-out prompts at configurable intervals (\texttt{held\_out\_interval}).
+A divergence exceeding 10\% triggers a warning; 25\% triggers a critical alert, indicating potential overfitting to the test prompt distribution.
 
 % ------------------------------------------------------------------
 % Architecture diagram placeholder
@@ -133,4 +161,3 @@ Held-out divergence detection runs stochastic evaluation against a separate set 
     \caption{\textsc{anneal} system architecture. The user registers a target as an Artifact--Eval--Agent triplet. The engine creates an isolated git worktree, invokes the mutation agent, enforces scope constraints, evaluates the mutated artifact, and applies a statistical acceptance test. Accepted mutations are committed; rejected mutations are reset.}
     \label{fig:architecture}
 \end{figure}
-

--- a/paper/sections/system_design.tex
+++ b/paper/sections/system_design.tex
@@ -1,4 +1,3 @@
-% !TEX root = ../main.tex
 \section{System Design}\label{sec:system-design}
 
 \textsc{anneal}'s architecture is organized around three invariants: the optimization target is always a text file in a git repository, the evaluation signal is always an external process the agent cannot influence, and mutations are always isolated in a dedicated worktree that the user's working tree never observes.


### PR DESCRIPTION
## Summary

Source-side cleanup of the paper LaTeX tree. Tightens prose punctuation, reflows section files for diff-friendliness, prunes the preamble, restores standard editor metadata, and adds the missing accessibility description. Rendered PDF holds at 18 pages; pdftotext output is byte-identical except for the intended punctuation substitutions.

## Changes by area

### Prose punctuation (341ab4d)
- Replaced ~30 mild em-dashes across all nine section files with parentheses (paired asides), colons (list introductions), or commas (mild appositives).
- Retained em-dashes that carry genuine emphatic-aside or restatement work (abstract gap restatement, discussion's nested-parens avoidance, results' \"as opposed to\" contrast).
- Table cell literals (`& --- &`), comment dividers, and en-dash compounds (`Holm--Bonferroni`, `Bradley--Terry`) untouched.

### Source reflow (5eb2c07)
- Converted `paper/sections/*.tex` from ~80-column hard-wrap to one-sentence-per-line per [sembr.org](https://sembr.org).
- LaTeX collapses single newlines into spaces, so PDF output is unchanged — verified via pdftotext byte-equality and held page count at 18.
- Comments, table rows, algorithm pseudocode, and `itemize` / `enumerate` structure preserved.
- Benefit is source-side: sentence-level diffs (one-word change touches one line, not a paragraph), trivial sentence reordering, and prose-readable in any editor. Explains why this PR's `--stat` shows a 665→277 line delta that is mostly reflow, not deletion.

### Editor metadata (c9b75f1, 7bf0b59, reverted 1318cc9)
- Added `% !TEX root = ../main.tex` to `abstract.tex`, `introduction.tex`, and `related_work.tex` — the three section files that previously lacked it. All nine sub-files now consistently declare `main.tex` as their root.
- Originally tried removing the comment from the other six files (1318cc9) on the premise that modern editors infer the root from workspace config. That premise was wrong: TeXShop, TeXstudio, TeXworks, VS Code (LaTeX Workshop), and Sublime LaTeXTools all rely on `% !TEX root` to delegate Build commands from a sub-file. Reverted (7bf0b59) and added the comment to the missing files instead.

### Preamble hygiene (261bf47)
- Dropped nine redundant `\usepackage` declarations: four already loaded by `acmart` (`booktabs`, `microtype`, `amsmath`, `xcolor`) and five with zero call sites in any section file (`todonotes`, `listings`, `subcaption`, `multirow`, `enumitem`).
- Retained the six packages that `acmart` does not provide and that are actually used: `cleveref`, `algorithm`, `algpseudocode`, `fancyhdr`, plus `silence` and `hyphenat` declared above.
- PDF byte size: 857486 → 857259 with no visible rendering change. Build is faster and the preamble no longer shadows acmart's own package choices.

### Build noise (62ff09e)
- Loaded the `silence` package and filtered two `latexfont` warnings that fire on every build (`T1/zi4` shape substitution under acmart and the generic \"Some font shapes were not available\" follow-on).
- Warnings are cosmetic — fonts substitute correctly and the PDF is unchanged — but they were burying real warnings in the log and making CI output noisier than necessary.

### Accessibility (d23b68a)
- Added `\Description{}` for `fig:architecture` via acmart's accessibility macro. acmart emits a `Package acmart Warning` at every build for figures lacking `\Description`, and the resulting PDF lacks the structural alt-text screen readers rely on.
- Description mirrors the caption's content in plain prose without LaTeX markup so assistive tooling can read it directly.

### Author metadata (7c02ea5)
- Added an `\affiliation{}` block declaring the author as an independent researcher based in Kochi, Kerala, India, using acmart's standard `\institution` / `\city` / `\state` / `\country` fields.
- Title block now renders with full metadata under the current `nonacm` preprint configuration. Flipping to a default acmart submission only requires removing `nonacm` from `\documentclass` options — no further author-block edits.

## Verification

- `pdftotext paper.pdf -` byte-identical to pre-change after the reflow commit (5eb2c07).
- pdftotext diff after em-dash commit (341ab4d) contains only the intended punctuation substitutions.
- Page count holds at 18 across all commits.
- LaTeX log no longer contains the two filtered `latexfont` warnings or the `acmart` `\Description` warning for `fig:architecture`.

## Test plan

- [ ] `cd paper && latexmk -pdf main.tex` builds clean (no new warnings beyond pre-existing ones).
- [ ] Open any of the nine `paper/sections/*.tex` files in TeXShop / VS Code (LaTeX Workshop) and confirm Build delegates to `paper/main.tex` via `% !TEX root`.
- [ ] Spot-check `paper/sections/related_work.tex` and `paper/sections/introduction.tex` in the rendered PDF — the two files with the largest reflow deltas — to confirm prose reads identically to `main`.
- [ ] Confirm title page shows the new `\affiliation{}` block under the author name.
- [ ] Inspect the architecture figure's PDF tags (or run a screen-reader pass) to confirm the `\Description` alt-text is reachable.