### PR TITLE
feat(agent): harden runtime stalls and retries

### DIFF
--- a/anneal/cli.py
+++ b/anneal/cli.py
@@ -11,6 +11,7 @@ import argparse
 import sys
 import time
 from pathlib import Path
+from typing import Literal
 
 from rich.console import Console
 from rich.panel import Panel
@@ -243,7 +244,9 @@ def _handle_register(args: argparse.Namespace) -> None:
             "agent", {}
         ).get("model", None)
         if judge_mode or judge_model:
-            effective_judge_mode = judge_mode or "api"
+            effective_judge_mode: Literal["claude_code", "api"] = (
+                "claude_code" if judge_mode == "claude_code" else "api"
+            )
             judge_budget = 0.50 if effective_judge_mode == "claude_code" else 0.02
             judgment_agent_config = AgentConfig(
                 mode=effective_judge_mode,
@@ -435,7 +438,12 @@ def _handle_register(args: argparse.Namespace) -> None:
                 f"  Worktree:     {target.worktree_path}\n"
                 f"  Branch:       {target.git_branch}\n"
                 f"  Time budget:  {target.time_budget_seconds}s\n"
-                f"  Budget cap:   ${target.budget_cap.max_usd_per_day:.2f}/day"
+                f"  Budget cap:   "
+                + (
+                    f"${target.budget_cap.max_usd_per_day:.2f}/day"
+                    if target.budget_cap is not None
+                    else "unset"
+                )
                 + (
                     f"\n  Criteria:     {len(stochastic_eval.criteria)} binary, "
                     f"{len(stochastic_eval.test_prompts)} test prompts, "
@@ -701,7 +709,10 @@ def _handle_run(args: argparse.Namespace) -> None:
         # Select search strategy
         # 10.1 — Simple mode default: HybridSearch (greedy x10 then annealing)
         # when no explicit --search flag is given.
+        from anneal.engine.search import SearchStrategy
+
         search_choice = getattr(args, "search", None)
+        search_strategy: SearchStrategy
         if search_choice == "greedy":
             search_strategy = GreedySearch()
         elif search_choice == "annealing":
@@ -720,10 +731,11 @@ def _handle_run(args: argparse.Namespace) -> None:
             if tree_path.exists():
                 search_strategy = UCBTreeSearch.load(tree_path)
             else:
-                search_strategy = UCBTreeSearch()
+                ucb_search = UCBTreeSearch()
                 records = knowledge.load_records()
                 if records:
-                    search_strategy.bootstrap_from_history(records)
+                    ucb_search.bootstrap_from_history(records)
+                search_strategy = ucb_search
         else:
             # Default: greedy phase (10 experiments) then simulated annealing
             from anneal.engine.search import HybridSearch  # noqa: F811
@@ -735,8 +747,8 @@ def _handle_run(args: argparse.Namespace) -> None:
             target.domain_tier is DomainTier.DEPLOYMENT
             and target.approval_callback is None
         ):
-            target.approval_callback = (
-                lambda diff: input("Apply changes? [y/N] ").lower() == "y"
+            target.approval_callback = lambda diff: (
+                input("Apply changes? [y/N] ").lower() == "y"
             )
 
         # Initialize failure taxonomy (with custom categories if registered)
@@ -1558,11 +1570,12 @@ def _handle_validate(args: argparse.Namespace) -> None:
 
         # Identify the weakest criterion
         if result.per_criterion_scores:
+            criterion_scores = result.per_criterion_scores
             weakest_name = min(
-                result.per_criterion_scores,
-                key=lambda k: result.per_criterion_scores[k],
-            )  # type: ignore[arg-type]
-            weakest_val = result.per_criterion_scores[weakest_name]
+                criterion_scores,
+                key=lambda k: criterion_scores[k],
+            )
+            weakest_val = criterion_scores[weakest_name]
             if weakest_val < 0.5:
                 console.print(
                     f"\n  Weakest criterion: [yellow]{weakest_name}[/yellow] "

--- a/anneal/engine/agent.py
+++ b/anneal/engine/agent.py
@@ -13,6 +13,7 @@ import os
 import re
 import signal
 from pathlib import Path
+from typing import Literal
 
 from anneal.engine.client import (
     compute_cost,
@@ -36,7 +37,7 @@ DIAGNOSIS_SYSTEM_PROMPT = (
     "Output valid JSON with these fields:\n"
     "- weakest_criteria: list of criterion names that failed or scored lowest\n"
     "- root_cause: one sentence explaining why these criteria failed\n"
-    "- fix_category: one of \"structural\", \"content\", \"formatting\", \"logic\", \"coverage\", \"other\"\n"
+    '- fix_category: one of "structural", "content", "formatting", "logic", "coverage", "other"\n'
     "- suggested_direction: 1-2 sentences describing what change would improve the weakest criteria"
 )
 
@@ -49,11 +50,101 @@ class AgentTimeoutError(AgentInvocationError):
     """Agent exceeded time budget."""
 
 
+class AgentStalledError(AgentTimeoutError):
+    """Agent emitted no output for stall_timeout_seconds.
+
+    Subclass of AgentTimeoutError so runner-level handlers that route
+    timeouts to ``Outcome.KILLED`` keep working without modification, but
+    distinguishable when retry classification needs the original signal.
+    """
+
+
+class AgentTransientError(AgentInvocationError):
+    """Retry-eligible failure (rate limit, 5xx, network blip, partial JSON).
+
+    Runner wraps invocation in an exponential-backoff retry loop that
+    catches this class and reissues the call within the same experiment
+    slot. Promoted to ``AgentStructuralError`` once the retry budget is
+    exhausted.
+    """
+
+
+class AgentStructuralError(AgentInvocationError):
+    """Terminal failure (auth error, schema break, agent-declined task).
+
+    Surfaces immediately as ``Outcome.CRASHED`` with no retry attempt.
+    """
+
+
+_TRANSIENT_HTTP_STATUSES: frozenset[int] = frozenset(
+    {408, 425, 429, 500, 502, 503, 504}
+)
+
+_TRANSIENT_STDERR_PATTERNS: tuple[str, ...] = (
+    "rate_limit",
+    "rate limit",
+    "overloaded",
+    "overloaded_error",
+    "service_unavailable",
+    "temporarily unavailable",
+    "connection reset",
+    "connection refused",
+    "connection timed out",
+    "read timed out",
+    "bad gateway",
+    "gateway timeout",
+    "ecconnreset",
+    "etimedout",
+)
+
+
+def _classify_api_exception(exc: BaseException) -> type[AgentInvocationError]:
+    """Map an arbitrary exception raised during an LLM API call to a
+    transient/structural class.
+
+    Conservative: defaults to ``AgentStructuralError`` on unknown types so
+    silent infinite-retry loops are impossible without an explicit
+    classification rule.
+    """
+    if isinstance(exc, asyncio.TimeoutError):
+        return AgentTransientError
+    if isinstance(exc, json.JSONDecodeError):
+        return AgentTransientError
+    if isinstance(exc, (ConnectionError, OSError)):
+        return AgentTransientError
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        response = getattr(exc, "response", None)
+        if response is not None:
+            status = getattr(response, "status_code", None)
+    if isinstance(status, int) and status in _TRANSIENT_HTTP_STATUSES:
+        return AgentTransientError
+    return AgentStructuralError
+
+
+def _classify_subprocess_failure(stderr_text: str) -> type[AgentInvocationError]:
+    """Classify a non-zero subprocess exit. Stderr substring match is
+    conservative: structural by default, transient only on known signals.
+    """
+    haystack = stderr_text.lower()
+    if any(needle in haystack for needle in _TRANSIENT_STDERR_PATTERNS):
+        return AgentTransientError
+    return AgentStructuralError
+
+
+def _kill_process_group(proc: asyncio.subprocess.Process) -> None:
+    """SIGKILL the subprocess's session group. Idempotent."""
+    if proc.returncode is not None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
 def _extract_hypothesis(text: str) -> str | None:
     """Extract hypothesis text after '## Hypothesis' header."""
-    match = re.search(
-        r"## Hypothesis\s*\n(.*?)(?=\n## |\Z)", text, re.DOTALL
-    )
+    match = re.search(r"## Hypothesis\s*\n(.*?)(?=\n## |\Z)", text, re.DOTALL)
     if match:
         content = match.group(1).strip()
         return content if content else None
@@ -94,7 +185,6 @@ def _extract_tags(text: str) -> list[str]:
     return []
 
 
-
 class AgentInvoker:
     """Invokes a mutation agent via Claude Code subprocess or direct API call."""
 
@@ -108,11 +198,16 @@ class AgentInvoker:
     ) -> AgentInvocationResult:
         if config.mode == "claude_code":
             return await self._invoke_claude_code(
-                config, prompt, worktree_path, time_budget_seconds,
+                config,
+                prompt,
+                worktree_path,
+                time_budget_seconds,
                 deployment_mode=deployment_mode,
             )
         elif config.mode == "api":
-            return await self._invoke_api(config, prompt, worktree_path, time_budget_seconds)
+            return await self._invoke_api(
+                config, prompt, worktree_path, time_budget_seconds
+            )
         else:
             raise AgentInvocationError(f"Unknown agent mode: {config.mode}")
 
@@ -128,7 +223,10 @@ class AgentInvoker:
         The agent outputs proposed changes as text only.
         """
         return await self.invoke(
-            config, prompt, worktree_path, time_budget_seconds,
+            config,
+            prompt,
+            worktree_path,
+            time_budget_seconds,
             deployment_mode=True,
         )
 
@@ -155,12 +253,18 @@ class AgentInvoker:
 
         if config.mode == "claude_code":
             return await self._invoke_claude_code(
-                config, full_prompt, worktree_path, time_budget_seconds,
+                config,
+                full_prompt,
+                worktree_path,
+                time_budget_seconds,
                 meta_mode=True,
             )
         elif config.mode == "api":
             return await self._invoke_api(
-                config, full_prompt, worktree_path, time_budget_seconds,
+                config,
+                full_prompt,
+                worktree_path,
+                time_budget_seconds,
             )
         else:
             raise AgentInvocationError(f"Unknown agent mode: {config.mode}")
@@ -180,18 +284,20 @@ class AgentInvoker:
             allowed_tools = "Read"
         else:
             allowed_tools = "Edit,Write"
-        assert "Bash" not in allowed_tools, (
-            "Bash must never appear in --allowedTools"
-        )
+        assert "Bash" not in allowed_tools, "Bash must never appear in --allowedTools"
 
         cmd = [
             "claude",
             "-p",
-            "--output-format", "json",
+            "--output-format",
+            "json",
             "--no-session-persistence",
-            "--allowedTools", allowed_tools,
-            "--max-budget-usd", str(config.max_budget_usd),
-            "--model", config.model,
+            "--allowedTools",
+            allowed_tools,
+            "--max-budget-usd",
+            str(config.max_budget_usd),
+            "--model",
+            config.model,
         ]
 
         proc = await asyncio.create_subprocess_exec(
@@ -203,24 +309,17 @@ class AgentInvoker:
             start_new_session=True,
         )
 
-        try:
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                proc.communicate(input=prompt.encode()),
-                timeout=time_budget_seconds,
-            )
-        except asyncio.TimeoutError:
-            try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-            except ProcessLookupError:
-                pass
-            raise AgentTimeoutError(
-                f"Agent exceeded time budget of {time_budget_seconds}s"
-            )
+        stdout_bytes, stderr_bytes = await self._run_with_stall_detection(
+            proc,
+            prompt.encode(),
+            wall_clock_seconds=time_budget_seconds,
+            stall_seconds=config.stall_timeout_seconds,
+        )
 
         stderr_text = stderr_bytes.decode(errors="replace")
 
         if proc.returncode != 0:
-            raise AgentInvocationError(
+            raise _classify_subprocess_failure(stderr_text)(
                 f"Claude Code exited with code {proc.returncode}: {stderr_text}"
             )
 
@@ -229,7 +328,7 @@ class AgentInvoker:
         try:
             response = json.loads(stdout_text)
         except json.JSONDecodeError as exc:
-            raise AgentInvocationError(
+            raise AgentTransientError(
                 f"Invalid JSON response from Claude Code: {exc}"
             ) from exc
 
@@ -237,7 +336,7 @@ class AgentInvoker:
         is_error = response.get("is_error", False)
         subtype = response.get("subtype", "")
         if is_error or (subtype and subtype.startswith("error_")):
-            raise AgentInvocationError(
+            raise AgentStructuralError(
                 f"Claude Code returned error: subtype={subtype}, "
                 f"cost=${response.get('total_cost_usd', 0):.4f}"
             )
@@ -249,7 +348,9 @@ class AgentInvoker:
         raw_output = response.get("result", "")
 
         hypothesis = _extract_hypothesis(raw_output)
-        hypothesis_source: str = "agent" if hypothesis is not None else "synthesized"
+        hypothesis_source: Literal["agent", "synthesized"] = (
+            "agent" if hypothesis is not None else "synthesized"
+        )
         tags = _extract_tags(raw_output)
 
         return AgentInvocationResult(
@@ -262,6 +363,96 @@ class AgentInvoker:
             tags=tags,
             raw_output=raw_output,
         )
+
+    async def _run_with_stall_detection(
+        self,
+        proc: asyncio.subprocess.Process,
+        prompt: bytes,
+        wall_clock_seconds: int,
+        stall_seconds: int,
+    ) -> tuple[bytes, bytes]:
+        """Drive ``proc`` to completion while watching for silent stalls.
+
+        Streams stdout/stderr concurrently, refreshing ``last_activity_ts``
+        on every chunk. A watchdog SIGKILLs the process group if the gap
+        between activity exceeds ``stall_seconds`` (``stall_seconds=0``
+        disables the watchdog). ``wall_clock_seconds`` remains the hard
+        backstop and is enforced as before via :class:`AgentTimeoutError`.
+
+        Returns the concatenated ``(stdout, stderr)`` byte buffers on
+        success. Raises :class:`AgentStalledError` on stall (subclass of
+        :class:`AgentTimeoutError`) or :class:`AgentTimeoutError` on
+        wall-clock exhaustion.
+        """
+        loop = asyncio.get_running_loop()
+        last_activity = loop.time()
+        stdout_chunks: list[bytes] = []
+        stderr_chunks: list[bytes] = []
+        stall_seen: list[float] = []
+
+        async def pump(stream: asyncio.StreamReader | None, sink: list[bytes]) -> None:
+            nonlocal last_activity
+            if stream is None:
+                return
+            while True:
+                chunk = await stream.read(4096)
+                if not chunk:
+                    return
+                sink.append(chunk)
+                last_activity = loop.time()
+
+        async def watchdog() -> None:
+            if stall_seconds <= 0:
+                return
+            tick = max(1.0, min(stall_seconds / 4, 15.0))
+            while proc.returncode is None:
+                await asyncio.sleep(tick)
+                elapsed = loop.time() - last_activity
+                if elapsed > stall_seconds:
+                    stall_seen.append(elapsed)
+                    _kill_process_group(proc)
+                    return
+
+        if proc.stdin is not None:
+            try:
+                proc.stdin.write(prompt)
+                await proc.stdin.drain()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            proc.stdin.close()
+
+        pump_stdout = asyncio.create_task(pump(proc.stdout, stdout_chunks))
+        pump_stderr = asyncio.create_task(pump(proc.stderr, stderr_chunks))
+        watch_task = asyncio.create_task(watchdog())
+        wait_task = asyncio.create_task(proc.wait())
+
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(pump_stdout, pump_stderr, watch_task, wait_task),
+                timeout=wall_clock_seconds,
+            )
+        except asyncio.TimeoutError:
+            _kill_process_group(proc)
+            for task in (pump_stdout, pump_stderr, watch_task, wait_task):
+                task.cancel()
+            await asyncio.gather(
+                pump_stdout,
+                pump_stderr,
+                watch_task,
+                wait_task,
+                return_exceptions=True,
+            )
+            raise AgentTimeoutError(
+                f"Agent exceeded wall-clock budget of {wall_clock_seconds}s"
+            )
+
+        if stall_seen:
+            raise AgentStalledError(
+                f"Agent emitted no output for {stall_seen[0]:.1f}s "
+                f"(stall_timeout={stall_seconds}s)"
+            )
+
+        return b"".join(stdout_chunks), b"".join(stderr_chunks)
 
     async def _invoke_api(
         self,
@@ -286,6 +477,8 @@ class AgentInvoker:
             raise AgentTimeoutError(
                 f"API agent exceeded time budget of {time_budget_seconds}s"
             )
+        except Exception as exc:
+            raise _classify_api_exception(exc)(f"API call failed: {exc}") from exc
 
         raw_output = response.choices[0].message.content or ""
 
@@ -295,7 +488,9 @@ class AgentInvoker:
         cost_usd = compute_cost(config.model, input_tokens, output_tokens)
 
         hypothesis = _extract_hypothesis(raw_output)
-        hypothesis_source: str = "agent" if hypothesis is not None else "synthesized"
+        hypothesis_source: Literal["agent", "synthesized"] = (
+            "agent" if hypothesis is not None else "synthesized"
+        )
         tags = _extract_tags(raw_output)
 
         return AgentInvocationResult(
@@ -324,7 +519,9 @@ class AgentInvoker:
         lines.append("## Evaluation Score")
         lines.append(f"Overall: {eval_result.score:.4f}")
         if eval_result.ci_lower is not None and eval_result.ci_upper is not None:
-            lines.append(f"CI: [{eval_result.ci_lower:.4f}, {eval_result.ci_upper:.4f}]")
+            lines.append(
+                f"CI: [{eval_result.ci_lower:.4f}, {eval_result.ci_upper:.4f}]"
+            )
         lines.append("")
 
         if eval_result.per_criterion_scores:
@@ -354,10 +551,14 @@ class AgentInvoker:
         recent_history: list[ExperimentRecord],
         worktree_path: Path,
     ) -> DiagnosisResult:
-        diagnosis_model = config.diagnosis_model or config.exploration_model or config.model
+        diagnosis_model = (
+            config.diagnosis_model or config.exploration_model or config.model
+        )
         client = make_client(diagnosis_model)
         api_model = strip_provider_prefix(diagnosis_model)
-        user_prompt = self._build_diagnosis_prompt(artifact_content, eval_result, recent_history)
+        user_prompt = self._build_diagnosis_prompt(
+            artifact_content, eval_result, recent_history
+        )
 
         try:
             response = await asyncio.wait_for(
@@ -432,11 +633,19 @@ class AgentInvoker:
             tasks = []
             for i in range(n_drafts):
                 temp_offset = (i - n_drafts // 2) * 0.1
-                draft_config = config.model_copy(update={
-                    "temperature": max(0.0, min(2.0, config.temperature + temp_offset)),
-                    "max_budget_usd": config.max_budget_usd / n_drafts,
-                })
-                tasks.append(self._invoke_api(draft_config, prompt, worktree_path, time_budget_seconds))
+                draft_config = config.model_copy(
+                    update={
+                        "temperature": max(
+                            0.0, min(2.0, config.temperature + temp_offset)
+                        ),
+                        "max_budget_usd": config.max_budget_usd / n_drafts,
+                    }
+                )
+                tasks.append(
+                    self._invoke_api(
+                        draft_config, prompt, worktree_path, time_budget_seconds
+                    )
+                )
 
             results = await asyncio.gather(*tasks, return_exceptions=True)
             for result in results:
@@ -449,12 +658,17 @@ class AgentInvoker:
         else:
             # Sequential claude_code invocations with diff capture
             for i in range(n_drafts):
-                draft_config = config.model_copy(update={
-                    "max_budget_usd": config.max_budget_usd / n_drafts,
-                })
+                draft_config = config.model_copy(
+                    update={
+                        "max_budget_usd": config.max_budget_usd / n_drafts,
+                    }
+                )
                 try:
                     result = await self._invoke_claude_code(
-                        draft_config, prompt, worktree_path, time_budget_seconds,
+                        draft_config,
+                        prompt,
+                        worktree_path,
+                        time_budget_seconds,
                     )
                     diff_text = await git.capture_diff(worktree_path)
                     drafts.append((result, diff_text))

--- a/anneal/engine/archive.py
+++ b/anneal/engine/archive.py
@@ -4,6 +4,7 @@ Maintains a grid of best solutions indexed by behavioral descriptors
 (e.g., per-criterion scores). Each cell holds the highest-fitness
 solution that maps to that behavioral region.
 """
+
 from __future__ import annotations
 
 import json
@@ -117,7 +118,7 @@ class MapElitesArchive:
             return 0
         sample = next(iter(self._archive.values()))
         n_dims = len(sample.behavior)
-        return self._n_bins ** n_dims
+        return int(self._n_bins**n_dims)
 
     def _save(self) -> None:
         """Persist archive to JSONL file."""

--- a/anneal/engine/bayesian.py
+++ b/anneal/engine/bayesian.py
@@ -4,22 +4,27 @@ Uses Gaussian Process regression (scikit-learn) to predict mutation
 scores from experiment history features. Falls back gracefully when
 scikit-learn is not installed.
 """
+
 from __future__ import annotations
 
 import logging
 import numpy as np
 from dataclasses import dataclass, field
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 _SKLEARN_AVAILABLE = False
 try:
-    from sklearn.gaussian_process import GaussianProcessRegressor
-    from sklearn.gaussian_process.kernels import Matern
+    from sklearn.gaussian_process import GaussianProcessRegressor as _GPR
+    from sklearn.gaussian_process.kernels import Matern as _Matern
+
+    GaussianProcessRegressor: Any = _GPR
+    Matern: Any = _Matern
     _SKLEARN_AVAILABLE = True
 except ImportError:
-    GaussianProcessRegressor = None  # type: ignore[misc,assignment]
-    Matern = None  # type: ignore[misc,assignment]
+    GaussianProcessRegressor = None
+    Matern = None
 
 
 @dataclass
@@ -33,7 +38,7 @@ class SurrogateModel:
 
     _observations_X: list[list[float]] = field(default_factory=list)
     _observations_y: list[float] = field(default_factory=list)
-    _model: object | None = None  # GaussianProcessRegressor when available
+    _model: Any = None  # GaussianProcessRegressor when available
     _fitted: bool = False
     min_observations: int = 10  # Don't predict until we have enough data
 

--- a/anneal/engine/context.py
+++ b/anneal/engine/context.py
@@ -9,11 +9,18 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from anneal.engine.types import ArtifactError, ExperimentRecord, Outcome, OptimizationTarget
+import tiktoken
+
+from anneal.engine.types import (
+    ArtifactError,
+    ExperimentRecord,
+    Outcome,
+    OptimizationTarget,
+)
 
 
 def _api_response_format_instruction(target: OptimizationTarget) -> str | None:
@@ -56,6 +63,7 @@ def _api_response_format_instruction(target: OptimizationTarget) -> str | None:
         "- Do not add explanations before, between, or after the sections."
     )
 
+
 if TYPE_CHECKING:
     from anneal.engine.knowledge import KnowledgeStore
     from anneal.engine.research import ResearchResult
@@ -66,8 +74,6 @@ logger = logging.getLogger(__name__)
 # Token estimation
 # ---------------------------------------------------------------------------
 
-
-import tiktoken
 
 _encoder = tiktoken.get_encoding("cl100k_base")
 
@@ -415,9 +421,13 @@ def _build_verifier_warning(history: list[ExperimentRecord]) -> str:
     if not warnings:
         return ""
 
-    return "# Verifier Failure Warnings\n\n" + "\n".join(warnings) + (
-        "\n\nFocus on producing mutations that pass these verification gates. "
-        "Review the verifier requirements before making changes."
+    return (
+        "# Verifier Failure Warnings\n\n"
+        + "\n".join(warnings)
+        + (
+            "\n\nFocus on producing mutations that pass these verification gates. "
+            "Review the verifier requirements before making changes."
+        )
     )
 
 
@@ -440,7 +450,11 @@ def _build_failure_distribution_summary(history: list[ExperimentRecord]) -> str:
     sorted_dist = sorted(dist.items(), key=lambda x: x[1], reverse=True)
     for cat, count in sorted_dist:
         pct = count / total_failures * 100
-        suffix = " ← most common" if cat == sorted_dist[0][0] and len(sorted_dist) > 1 else ""
+        suffix = (
+            " ← most common"
+            if cat == sorted_dist[0][0] and len(sorted_dist) > 1
+            else ""
+        )
         lines.append(f"- {cat}: {count} ({pct:.0f}%){suffix}")
 
     # Blind spot check
@@ -448,7 +462,9 @@ def _build_failure_distribution_summary(history: list[ExperimentRecord]) -> str:
     blind_spots = taxonomy.blind_spot_check(history)
     if blind_spots:
         for bs in blind_spots:
-            lines.append(f"- [blind spot] {bs}: 0 attributions across {total_failures} failures")
+            lines.append(
+                f"- [blind spot] {bs}: 0 attributions across {total_failures} failures"
+            )
 
     if sorted_dist:
         top_cat = sorted_dist[0][0]
@@ -485,12 +501,13 @@ def build_target_context(
 
     knowledge_dir = repo_root / target.knowledge_path
     strategy = load_strategy(knowledge_dir)
+    program_content: str
     if strategy is not None:
         program_content = render_manifest_as_prompt(strategy)
     else:
         program_path = knowledge_dir / "program.md"
-        program_content = _read_file_safe(program_path)
-        if program_content is None:
+        loaded = _read_file_safe(program_path)
+        if loaded is None:
             program_content = (
                 f"# Optimization Target: {target.id}\n\n"
                 f"You are optimizing artifacts to improve the metric "
@@ -504,6 +521,8 @@ def build_target_context(
             logger.info(
                 "No program.md found at %s, using generated default", program_path
             )
+        else:
+            program_content = loaded
 
     budget.add_slot("system_prompt", program_content, priority=1, required=True)
 
@@ -512,7 +531,8 @@ def build_target_context(
         budget.add_slot(
             "policy_instructions",
             f"# Mutation Strategy\n\n{policy_instructions}",
-            priority=2, required=True,
+            priority=2,
+            required=True,
         )
 
     # Slot 2/3: Artifact (current best version of editable files)
@@ -521,9 +541,7 @@ def build_target_context(
         artifact_path = worktree_path / artifact_rel
         content = _read_file_safe(artifact_path)
         if content is not None:
-            artifact_parts.append(
-                f"### {artifact_rel}\n```\n{content}\n```"
-            )
+            artifact_parts.append(f"### {artifact_rel}\n```\n{content}\n```")
         else:
             logger.warning("Artifact file not found: %s", artifact_path)
 
@@ -557,7 +575,10 @@ def build_target_context(
     api_instruction = _api_response_format_instruction(target)
     if api_instruction is not None:
         budget.add_slot(
-            "api_response_format", api_instruction, priority=1, required=True,
+            "api_response_format",
+            api_instruction,
+            priority=1,
+            required=True,
         )
 
     # Slot 4: Recent history (last 5 experiment records)
@@ -572,7 +593,9 @@ def build_target_context(
             lineage = knowledge.get_lineage(kept_records[-1].git_sha, depth=5)
             if lineage:
                 lineage_content = _format_lineage(lineage)
-                budget.add_slot("lineage_trace", lineage_content, priority=5, required=False)
+                budget.add_slot(
+                    "lineage_trace", lineage_content, priority=5, required=False
+                )
 
     # Slot 5b: Research suggestions (injected after plateau-triggered research)
     if research_hints is not None and research_hints.suggestions:
@@ -588,7 +611,9 @@ def build_target_context(
             "These are suggestions from external research. "
             "Use them as inspiration if relevant. Ignore if not applicable."
         )
-        budget.add_slot("research_hints", "\n".join(parts_hints), priority=5, required=False)
+        budget.add_slot(
+            "research_hints", "\n".join(parts_hints), priority=5, required=False
+        )
 
     # Slot 6: Knowledge context (retrieved history + consolidated learnings)
     if knowledge_context:
@@ -674,8 +699,10 @@ def build_restart_context(
     )
 
     budget.add_slot(
-        "system_prompt", program_content + restart_instruction,
-        priority=1, required=True,
+        "system_prompt",
+        program_content + restart_instruction,
+        priority=1,
+        required=True,
     )
 
     # API-mode response-format directive (restart context has no existing
@@ -684,7 +711,10 @@ def build_restart_context(
     api_instruction = _api_response_format_instruction(target)
     if api_instruction is not None:
         budget.add_slot(
-            "api_response_format", api_instruction, priority=1, required=True,
+            "api_response_format",
+            api_instruction,
+            priority=1,
+            required=True,
         )
 
     # Slot 2: Scope definition (what files to create/modify)
@@ -694,11 +724,13 @@ def build_restart_context(
         budget.add_slot(
             "scope_definition",
             f"# Scope Definition\n\n```yaml\n{scope_content}\n```",
-            priority=2, required=True,
+            priority=2,
+            required=True,
         )
 
     # Slot 3: Watch file contents (reference material, read-only context)
     from anneal.engine.scope import ScopeError, load_scope
+
     try:
         scope = load_scope(scope_path)
         watch_parts: list[str] = []
@@ -711,7 +743,8 @@ def build_restart_context(
             budget.add_slot(
                 "watch_files",
                 "# Reference Files (read-only)\n\n" + "\n\n".join(watch_parts),
-                priority=3, required=False,
+                priority=3,
+                required=False,
             )
     except ScopeError:
         logger.debug("Scope loading failed for restart context, skipping watch files")

--- a/anneal/engine/dashboard.py
+++ b/anneal/engine/dashboard.py
@@ -156,7 +156,8 @@ class AnnealStateReader:
         if not status_path.exists():
             return None
         try:
-            return json.loads(status_path.read_text(encoding="utf-8"))
+            data: dict[str, Any] = json.loads(status_path.read_text(encoding="utf-8"))
+            return data
         except (json.JSONDecodeError, OSError):
             return None
 
@@ -184,7 +185,9 @@ class AnnealStateReader:
                 outcome_counts[oc] = outcome_counts.get(oc, 0) + 1
             kept_count = outcome_counts.get("KEPT", 0)
             kept_rate = kept_count / experiment_count if experiment_count > 0 else 0.0
-            durations = [r["duration_seconds"] for r in records if "duration_seconds" in r]
+            durations = [
+                r["duration_seconds"] for r in records if "duration_seconds" in r
+            ]
             avg_duration = sum(durations) / len(durations) if durations else 0.0
             best_score = max(scores) if scores else meta.get("baseline", 0.0)
 
@@ -194,7 +197,9 @@ class AnnealStateReader:
                 "eval_mode": meta.get("eval_mode", "unknown"),
                 "git_branch": meta.get("git_branch", ""),
                 "experiment_count": experiment_count,
-                "score": last_record["score"] if last_record else meta.get("baseline", 0.0),
+                "score": last_record["score"]
+                if last_record
+                else meta.get("baseline", 0.0),
                 "outcome": last_record.get("outcome") if last_record else None,
                 "hypothesis": last_record.get("hypothesis") if last_record else None,
                 "cost": last_record.get("cost_usd", 0.0) if last_record else 0.0,
@@ -225,7 +230,10 @@ class AnnealStateReader:
         for pareto_path in candidates:
             if pareto_path.exists():
                 try:
-                    return json.loads(pareto_path.read_text(encoding="utf-8"))
+                    data: list[dict[str, float]] = json.loads(
+                        pareto_path.read_text(encoding="utf-8")
+                    )
+                    return data
                 except (json.JSONDecodeError, OSError):
                     return None
         return None
@@ -273,22 +281,30 @@ class FilePollingBus:
             for tid in targets_meta:
                 new_records = self._reader.read_new_experiments(tid)
                 for record in new_records:
-                    self.publish("experiment_complete", {
-                        "target_id": tid,
-                        "score": record.get("score", 0.0),
-                        "baseline": record.get("baseline_score", 0.0),
-                        "outcome": record.get("outcome", "UNKNOWN"),
-                        "hypothesis": (record.get("hypothesis") or "")[:200],
-                        "cost": record.get("cost_usd", 0.0),
-                        "duration": record.get("duration_seconds", 0.0),
-                    })
+                    self.publish(
+                        "experiment_complete",
+                        {
+                            "target_id": tid,
+                            "score": record.get("score", 0.0),
+                            "baseline": record.get("baseline_score", 0.0),
+                            "outcome": record.get("outcome", "UNKNOWN"),
+                            "hypothesis": (record.get("hypothesis") or "")[:200],
+                            "cost": record.get("cost_usd", 0.0),
+                            "duration": record.get("duration_seconds", 0.0),
+                        },
+                    )
                     pareto_front = self._reader._read_pareto_front(tid)
                     if pareto_front:
-                        self.publish("pareto_update", {
-                            "target_id": tid,
-                            "front": pareto_front,
-                            "criterion_names": list(pareto_front[0].keys()) if pareto_front else [],
-                        })
+                        self.publish(
+                            "pareto_update",
+                            {
+                                "target_id": tid,
+                                "front": pareto_front,
+                                "criterion_names": list(pareto_front[0].keys())
+                                if pareto_front
+                                else [],
+                            },
+                        )
 
     def stop(self) -> None:
         self._polling = False
@@ -716,7 +732,9 @@ class DashboardServer:
         self._poll_task = asyncio.create_task(self._bus.poll_loop())
         logger.info(
             "Dashboard serving .anneal/ at %s — http://%s:%d",
-            self._reader.root, self._host, self._port,
+            self._reader.root,
+            self._host,
+            self._port,
         )
 
     async def stop(self) -> None:

--- a/anneal/engine/knowledge.py
+++ b/anneal/engine/knowledge.py
@@ -14,6 +14,7 @@ from collections import Counter
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
@@ -36,13 +37,13 @@ _EMBEDDING_AVAILABLE = False
 _embedding_model = None
 
 
-def _get_embedding_model() -> object:  # SentenceTransformer | None (optional dep)
+def _get_embedding_model() -> Any:  # SentenceTransformer | None (optional dep)
     """Lazy-load sentence transformer model."""
     global _embedding_model, _EMBEDDING_AVAILABLE
     if _embedding_model is not None:
         return _embedding_model
     try:
-        from sentence_transformers import SentenceTransformer  # type: ignore[import-not-found]
+        from sentence_transformers import SentenceTransformer
 
         _embedding_model = SentenceTransformer("all-MiniLM-L6-v2")
         _EMBEDDING_AVAILABLE = True
@@ -389,8 +390,8 @@ class KnowledgeStore:
         texts = [e["hypothesis"] for e in entries]
         ids = [e["id"] for e in entries]
 
-        query_emb = model.encode(query, convert_to_numpy=True)  # type: ignore[union-attr]
-        doc_embs = model.encode(texts, convert_to_numpy=True)  # type: ignore[union-attr]
+        query_emb = model.encode(query, convert_to_numpy=True)
+        doc_embs = model.encode(texts, convert_to_numpy=True)
 
         query_norm = query_emb / (np.linalg.norm(query_emb) + 1e-10)
         doc_norms = doc_embs / (np.linalg.norm(doc_embs, axis=1, keepdims=True) + 1e-10)
@@ -526,7 +527,7 @@ class KnowledgeStore:
             for i in range(max_criterion_count):
                 name = crit_names[i] if i < len(crit_names) else f"criterion_{i}"
                 values = [
-                    r.raw_scores[i]  # type: ignore[index]
+                    r.raw_scores[i]
                     for r in records_with_raw
                     if r.raw_scores is not None and len(r.raw_scores) > i
                 ]
@@ -723,6 +724,7 @@ class KnowledgeStore:
                 "Explore broadly — try a meaningful change and observe the effect."
             )
 
+        sections: list[str]
         if count < self.COLD_START_THRESHOLD:
             recent = self.load_records()
             sections = [
@@ -738,7 +740,7 @@ class KnowledgeStore:
             return "\n".join(sections)
 
         # Full context: recent + similar + learnings
-        sections: list[str] = []
+        sections = []
 
         # Last 5 records
         recent = self.load_records(limit=5)

--- a/anneal/engine/learning_pool.py
+++ b/anneal/engine/learning_pool.py
@@ -108,16 +108,22 @@ def extract_learning(
         criterion_names = list(previous_per_criterion.keys())
         for i, name in enumerate(criterion_names):
             if i < len(record.raw_scores):
-                criterion_deltas[name] = record.raw_scores[i] - previous_per_criterion[name]
+                criterion_deltas[name] = (
+                    record.raw_scores[i] - previous_per_criterion[name]
+                )
 
     # Build deterministic observation text
     parts: list[str] = []
     parts.append(f"Hypothesis: {record.hypothesis}")
     parts.append(f"Outcome: {record.outcome.value}")
-    parts.append(f"Score delta: {score_delta:+.4f} ({record.baseline_score:.4f} -> {record.score:.4f})")
+    parts.append(
+        f"Score delta: {score_delta:+.4f} ({record.baseline_score:.4f} -> {record.score:.4f})"
+    )
 
     if criterion_deltas:
-        sorted_criteria = sorted(criterion_deltas.items(), key=lambda x: abs(x[1]), reverse=True)
+        sorted_criteria = sorted(
+            criterion_deltas.items(), key=lambda x: abs(x[1]), reverse=True
+        )
         top = sorted_criteria[:3]
         criterion_parts = [f"{name}: {delta:+.4f}" for name, delta in top]
         parts.append(f"Top criterion changes: {', '.join(criterion_parts)}")
@@ -160,16 +166,23 @@ def _dict_to_learning(d: dict[str, object]) -> Learning:
     else:
         created_at = datetime.now(UTC)
 
+    raw_ids = d["source_experiment_ids"]
+    raw_deltas = d["criterion_deltas"]
+    raw_tags = d["tags"]
+    assert isinstance(raw_ids, list), "source_experiment_ids must be a list"
+    assert isinstance(raw_deltas, dict), "criterion_deltas must be a dict"
+    assert isinstance(raw_tags, list), "tags must be a list"
+
     return Learning(
         observation=str(d["observation"]),
         signal=LearningSignal(d["signal"]),
         source_condition=str(d["source_condition"]),
         source_target=str(d["source_target"]),
-        source_experiment_ids=list(d["source_experiment_ids"]),  # type: ignore[arg-type]
+        source_experiment_ids=[int(x) for x in raw_ids],
         score_delta=float(d["score_delta"]),  # type: ignore[arg-type]
-        criterion_deltas={str(k): float(v) for k, v in d["criterion_deltas"].items()},  # type: ignore[union-attr]
+        criterion_deltas={str(k): float(v) for k, v in raw_deltas.items()},
         confidence=float(d["confidence"]),  # type: ignore[arg-type]
-        tags=[str(t) for t in d["tags"]],  # type: ignore[union-attr]
+        tags=[str(t) for t in raw_tags],
         created_at=created_at,
         project_id=str(d.get("project_id", "")),
         domain=str(d.get("domain", "")),
@@ -186,7 +199,9 @@ class LearningPool:
 
     DEFAULT_MAX_SIZE = 1000
 
-    def __init__(self, decay_rate: float = 0.05, max_size: int = DEFAULT_MAX_SIZE) -> None:
+    def __init__(
+        self, decay_rate: float = 0.05, max_size: int = DEFAULT_MAX_SIZE
+    ) -> None:
         self._learnings: list[Learning] = []
         self._decay_rate = decay_rate
         self._max_size = max_size
@@ -201,7 +216,7 @@ class LearningPool:
         """Remove lowest-impact learnings. Break ties randomly."""
         scored = sorted(
             self._learnings,
-            key=lambda l: (self._effective_score(l), random.random()),
+            key=lambda learning: (self._effective_score(learning), random.random()),
             reverse=True,
         )
         self._learnings = scored[: self._max_size]
@@ -246,19 +261,23 @@ class LearningPool:
         candidates = self._learnings
 
         if exclude_condition is not None:
-            candidates = [l for l in candidates if l.source_condition != exclude_condition]
+            candidates = [
+                c for c in candidates if c.source_condition != exclude_condition
+            ]
 
         if signal is not None:
-            candidates = [l for l in candidates if l.signal is signal]
+            candidates = [c for c in candidates if c.signal is signal]
 
         if source_condition is not None:
-            candidates = [l for l in candidates if l.source_condition == source_condition]
+            candidates = [
+                c for c in candidates if c.source_condition == source_condition
+            ]
 
         if source_target is not None:
-            candidates = [l for l in candidates if l.source_target == source_target]
+            candidates = [c for c in candidates if c.source_target == source_target]
 
         if project_id is not None:
-            candidates = [l for l in candidates if l.project_id == project_id]
+            candidates = [c for c in candidates if c.project_id == project_id]
 
         # Scope filtering: narrow by scope semantics
         # CONDITION scope requires source_condition filter (caller must provide)
@@ -275,6 +294,7 @@ class LearningPool:
         candidates = sorted(candidates, key=_domain_adjusted_score, reverse=True)
 
         if domain_tags:
+
             def _tag_boost(learning: Learning) -> float:
                 lesson_tags = self._extract_tags(learning.observation)
                 overlap = len(set(domain_tags) & set(lesson_tags))
@@ -283,14 +303,15 @@ class LearningPool:
             candidates = sorted(candidates, key=_tag_boost, reverse=True)
 
         # Return with decayed confidence values
-        return [self._decay_confidence(l) for l in candidates[:k]]
+        return [self._decay_confidence(c) for c in candidates[:k]]
 
     @staticmethod
     def _extract_tags(observation: str) -> list[str]:
         """Extract domain_tags from a learning observation that may contain JSON lesson data."""
         try:
             data = json.loads(observation)
-            return data.get("domain_tags", [])
+            tags = data.get("domain_tags", []) if isinstance(data, dict) else []
+            return [str(t) for t in tags]
         except (json.JSONDecodeError, TypeError):
             return []
 
@@ -328,7 +349,9 @@ class LearningPool:
                     key=lambda x: abs(x[1]),
                     reverse=True,
                 )[:3]
-                criterion_str = ", ".join(f"{name}: {d:+.2f}" for name, d in top_criteria)
+                criterion_str = ", ".join(
+                    f"{name}: {d:+.2f}" for name, d in top_criteria
+                )
                 line += f"\n   Criteria: {criterion_str}"
             lines.append(line)
 

--- a/anneal/engine/notifications.py
+++ b/anneal/engine/notifications.py
@@ -11,6 +11,7 @@ import json
 import logging
 import time
 from pathlib import Path
+from typing import Any
 
 import httpx
 
@@ -80,7 +81,7 @@ class NotificationManager:
 
         return await self._deliver(payload)
 
-    async def _deliver(self, payload: dict) -> bool:
+    async def _deliver(self, payload: dict[str, Any]) -> bool:
         """Deliver payload to primary webhook, falling back to secondary on failure."""
         primary = self._config.webhook_url
         if primary is None:
@@ -100,7 +101,7 @@ class NotificationManager:
         )
         return False
 
-    async def _fire_webhook(self, url: str, payload: dict) -> bool:
+    async def _fire_webhook(self, url: str, payload: dict[str, Any]) -> bool:
         """POST JSON to url with retry (config.webhook_retry_count attempts, exponential backoff)."""
         retry_count = self._config.webhook_retry_count
         base_delay = self._config.webhook_retry_delay_seconds
@@ -117,7 +118,7 @@ class NotificationManager:
                     return True
             except Exception as exc:
                 if attempt < retry_count - 1:
-                    delay = base_delay * (2 ** attempt)
+                    delay = base_delay * (2**attempt)
                     logger.warning(
                         "Webhook POST to %s failed (attempt %d/%d): %s — retrying in %.1fs",
                         url,

--- a/anneal/engine/runner.py
+++ b/anneal/engine/runner.py
@@ -23,13 +23,14 @@ from typing import Literal
 from anneal.engine.agent import (
     AgentInvocationError,
     AgentInvoker,
+    AgentStructuralError,
     AgentTimeoutError,
+    AgentTransientError,
     extract_code_block,
 )
 from anneal.engine.context import build_restart_context, build_target_context
 from anneal.engine.environment import FileBackupEnvironment, GitEnvironment, GitError
 from anneal.engine.eval import EvalEngine, EvalError, run_verifiers
-from anneal.engine.eval_cache import EvalCache
 from anneal.engine.knowledge import KnowledgeStore, extract_lesson
 from anneal.engine.learning_pool import LearningPool, extract_learning
 from anneal.engine.notifications import NotificationManager
@@ -367,14 +368,15 @@ class ExperimentRunner:
                 effective_restart_p,
             )
 
+        history: list[ExperimentRecord] = []
+        knowledge_context = ""
+
         if is_restart:
             prompt, _context_tokens = build_restart_context(
                 target=target,
                 worktree_path=worktree,
                 repo_root=self._repo_root or worktree,
             )
-            history = []
-            knowledge_context = ""
         else:
             # Auto-enable knowledge injection after sufficient KEPT experiments
             inject_knowledge = target.inject_knowledge_context
@@ -392,8 +394,6 @@ class ExperimentRunner:
                         kept_total,
                     )
 
-            history = []
-            knowledge_context = ""
             if self._knowledge and inject_knowledge:
                 history = self._knowledge.load_records(limit=10)
                 knowledge_context = self._knowledge.get_context()
@@ -578,10 +578,7 @@ class ExperimentRunner:
             # them in context.py) and fall through to scope enforcement, which
             # produces the standard "Agent made no file changes" BLOCKED
             # record.
-            if (
-                target.agent_config.mode == "api"
-                and len(target.artifact_paths) == 1
-            ):
+            if target.agent_config.mode == "api" and len(target.artifact_paths) == 1:
                 new_content = extract_code_block(agent_result.raw_output)
                 if new_content is not None:
                     artifact_abs = worktree / target.artifact_paths[0]
@@ -720,6 +717,69 @@ class ExperimentRunner:
     # Pipeline stages
     # ------------------------------------------------------------------
 
+    async def _invoke_with_transient_retries(
+        self,
+        target: OptimizationTarget,
+        prompt: str,
+        worktree: Path,
+        *,
+        deployment: bool,
+    ) -> AgentInvocationResult:
+        """Drive ``self._agent.invoke[_deployment]`` with within-experiment
+        retry on :class:`AgentTransientError`.
+
+        Retry semantics: ``max_transient_retries`` extra attempts on top of
+        the initial call. Backoff is exponential —
+        ``transient_retry_base_seconds * 2**attempt`` capped at
+        ``transient_retry_cap_seconds``. Wall-clock and stall timeouts
+        propagate to the outer handler unchanged. Once the budget is
+        exhausted the final exception is repackaged as
+        :class:`AgentStructuralError` so the runner's existing
+        ``Outcome.CRASHED`` arm handles it.
+        """
+        config = target.agent_config
+        max_retries = config.max_transient_retries
+        last_exc: AgentTransientError | None = None
+
+        for attempt in range(max_retries + 1):
+            try:
+                if deployment:
+                    return await self._agent.invoke_deployment(
+                        config,
+                        prompt,
+                        worktree,
+                        target.time_budget_seconds,
+                    )
+                return await self._agent.invoke(
+                    config,
+                    prompt,
+                    worktree,
+                    target.time_budget_seconds,
+                )
+            except AgentTransientError as exc:
+                last_exc = exc
+                if attempt >= max_retries:
+                    break
+                backoff = min(
+                    config.transient_retry_base_seconds * (2**attempt),
+                    config.transient_retry_cap_seconds,
+                )
+                logger.warning(
+                    "Transient agent failure on target=%s attempt=%d/%d, "
+                    "backing off %.1fs: %s",
+                    target.id,
+                    attempt + 1,
+                    max_retries + 1,
+                    backoff,
+                    exc,
+                )
+                await asyncio.sleep(backoff)
+
+        assert last_exc is not None
+        raise AgentStructuralError(
+            f"Transient retries exhausted ({max_retries}): {last_exc}"
+        ) from last_exc
+
     async def _invoke_agent(
         self,
         target: OptimizationTarget,
@@ -733,11 +793,11 @@ class ExperimentRunner:
         or ExperimentRecord on early exit (timeout, crash, approval rejection)."""
         try:
             if target.domain_tier is DomainTier.DEPLOYMENT:
-                agent_result = await self._agent.invoke_deployment(
-                    target.agent_config,
+                agent_result = await self._invoke_with_transient_retries(
+                    target,
                     prompt,
                     worktree,
-                    target.time_budget_seconds,
+                    deployment=True,
                 )
                 if target.approval_callback is None:
                     raise ValueError(
@@ -759,11 +819,11 @@ class ExperimentRunner:
                         cost_usd=agent_result.cost_usd,
                     )
             else:
-                agent_result = await self._agent.invoke(
-                    target.agent_config,
+                agent_result = await self._invoke_with_transient_retries(
+                    target,
                     prompt,
                     worktree,
-                    target.time_budget_seconds,
+                    deployment=False,
                 )
         except AgentTimeoutError as exc:
             await self._handle_killed(worktree, pre_sha)

--- a/anneal/engine/scheduler.py
+++ b/anneal/engine/scheduler.py
@@ -7,7 +7,7 @@ import logging
 import time
 from pathlib import Path
 
-from filelock import FileLock, Timeout
+from filelock import BaseFileLock, FileLock, Timeout
 
 from anneal.engine.types import OptimizationTarget
 
@@ -35,7 +35,7 @@ class Scheduler:
         self._targets = {t.id: t for t in targets}
         self._max_skip_threshold = max_skip_threshold
         self._skip_counts: dict[str, int] = {t.id: 0 for t in targets}
-        self._locks: dict[str, FileLock] = {}
+        self._locks: dict[str, BaseFileLock] = {}
         self._halted: set[str] = set()
 
     # ------------------------------------------------------------------
@@ -63,9 +63,7 @@ class Scheduler:
                 lock_path = self._lock_path(target)
                 lock_path.unlink(missing_ok=True)
                 self._skip_counts[target_id] = 0
-                logger.warning(
-                    "Removed stale lock for target %s (age > 1h)", target_id
-                )
+                logger.warning("Removed stale lock for target %s (age > 1h)", target_id)
 
             lock = self._make_lock(target)
 
@@ -97,7 +95,7 @@ class Scheduler:
     # Lock lifecycle
     # ------------------------------------------------------------------
 
-    def acquire_lock(self, target_id: str) -> FileLock:
+    def acquire_lock(self, target_id: str) -> BaseFileLock:
         """Acquire the target's lock. Returns the lock for the caller to release."""
         target = self._resolve_target(target_id)
         lock = self._make_lock(target)
@@ -109,9 +107,7 @@ class Scheduler:
         """Release the target's lock."""
         lock = self._locks.pop(target_id, None)
         if lock is None:
-            raise SchedulerError(
-                f"No active lock for target {target_id!r}"
-            )
+            raise SchedulerError(f"No active lock for target {target_id!r}")
         lock.release()
 
     # ------------------------------------------------------------------
@@ -145,7 +141,9 @@ class Scheduler:
         path = Path(target.worktree_path).resolve() / ".anneal.lock"
         return path
 
-    def _is_lock_stale(self, target: OptimizationTarget, max_age_seconds: int = 3600) -> bool:
+    def _is_lock_stale(
+        self, target: OptimizationTarget, max_age_seconds: int = 3600
+    ) -> bool:
         """Return True if the lock file is older than *max_age_seconds*."""
         lock_path = self._lock_path(target)
         if not lock_path.exists():
@@ -153,5 +151,5 @@ class Scheduler:
         age = time.time() - lock_path.stat().st_mtime
         return age > max_age_seconds
 
-    def _make_lock(self, target: OptimizationTarget) -> FileLock:
-        return FileLock(str(self._lock_path(target)), timeout=0)  # type: ignore[return-value]
+    def _make_lock(self, target: OptimizationTarget) -> BaseFileLock:
+        return FileLock(str(self._lock_path(target)), timeout=0)

--- a/anneal/engine/search.py
+++ b/anneal/engine/search.py
@@ -131,9 +131,9 @@ class GreedySearch:
                 sum((d - mean_diff) ** 2 for d in differences) / max(n - 1, 1)
             ) ** 0.5
             if std_diff == 0:
-                return mean_diff != 0  # All identical differences
+                return bool(mean_diff != 0)  # All identical differences
             effect_size = abs(mean_diff) / std_diff
-            return effect_size > 0.5  # Medium effect (Cohen's d)
+            return bool(effect_size > 0.5)  # Medium effect (Cohen's d)
 
         alternative = "greater" if direction is Direction.HIGHER_IS_BETTER else "less"
 

--- a/anneal/engine/strategy.py
+++ b/anneal/engine/strategy.py
@@ -101,9 +101,13 @@ def _summarize_criterion_performance(records: list[ExperimentRecord]) -> str:
         return "No per-criterion data available."
 
     lines: list[str] = []
-    for name, stats in sorted(criterion_stats.items(), key=lambda kv: kv[1]["fail"], reverse=True):
+    for name, stats in sorted(
+        criterion_stats.items(), key=lambda kv: kv[1]["fail"], reverse=True
+    ):
         total = stats["pass"] + stats["fail"]
-        lines.append(f"- {name}: {stats['pass']}/{total} passed ({stats['fail']} failures)")
+        lines.append(
+            f"- {name}: {stats['pass']}/{total} passed ({stats['fail']} failures)"
+        )
     return "\n".join(lines)
 
 
@@ -118,8 +122,7 @@ def evolve_weakest_component(
     target = manifest.weakest_component()
 
     relevant_records = [
-        r for r in records
-        if r.outcome in (Outcome.KEPT, Outcome.DISCARDED)
+        r for r in records if r.outcome in (Outcome.KEPT, Outcome.DISCARDED)
     ]
 
     kept_count = sum(1 for r in relevant_records if r.outcome is Outcome.KEPT)
@@ -138,7 +141,7 @@ def evolve_weakest_component(
         prompt += "- Score range: N/A\n\n"
 
     prompt += (
-        f"### Per-criterion feedback from relevant experiments\n"
+        "### Per-criterion feedback from relevant experiments\n"
         + _summarize_criterion_performance(relevant_records)
         + "\n\n"
         f"Revise ONLY the '{target.name}' component. "

--- a/anneal/engine/tree_search.py
+++ b/anneal/engine/tree_search.py
@@ -1,4 +1,5 @@
 """UCB tree search over artifact space for backtracking and branch exploration."""
+
 from __future__ import annotations
 
 import json
@@ -61,10 +62,14 @@ class UCBTreeSearch:
         if self._total_visits == 0:
             return node.score
         exploitation = node.score
-        exploration = self._c * math.sqrt(math.log(self._total_visits) / node.visit_count)
+        exploration = self._c * math.sqrt(
+            math.log(self._total_visits) / node.visit_count
+        )
         return exploitation + exploration
 
-    def _add_node(self, sha: str, score: float, parent_sha: str | None = None) -> TreeNode:
+    def _add_node(
+        self, sha: str, score: float, parent_sha: str | None = None
+    ) -> TreeNode:
         """Add a node to the tree. If it exists, update score."""
         if sha in self._nodes:
             node = self._nodes[sha]
@@ -90,7 +95,8 @@ class UCBTreeSearch:
             raise ValueError("Tree is empty — cannot select parent")
 
         candidates = [
-            node for node in self._nodes.values()
+            node
+            for node in self._nodes.values()
             if not node.pruned and self._depth(node) < self._max_depth
         ]
         if not candidates:
@@ -122,7 +128,7 @@ class UCBTreeSearch:
         self._total_visits += 1
 
         # Propagate visit to ancestors
-        current_sha = parent_sha
+        current_sha: str | None = parent_sha
         while current_sha is not None and current_sha in self._nodes:
             self._nodes[current_sha].visit_count += 1
             current_sha = self._nodes[current_sha].parent_sha
@@ -136,11 +142,11 @@ class UCBTreeSearch:
         if sha not in self._nodes:
             return
         node = self._nodes[sha]
-        non_improving = sum(
-            1 for child in node.children
-            if child.score <= node.score
-        )
-        if non_improving >= self._prune_threshold and len(node.children) >= self._prune_threshold:
+        non_improving = sum(1 for child in node.children if child.score <= node.score)
+        if (
+            non_improving >= self._prune_threshold
+            and len(node.children) >= self._prune_threshold
+        ):
             self.prune_subtree(sha)
 
     def prune_subtree(self, sha: str) -> None:
@@ -163,6 +169,8 @@ class UCBTreeSearch:
         direction: Direction,
         min_improvement_threshold: float = 0.0,
         confidence: float = 0.95,
+        experiment_index: int = 0,
+        holm_bonferroni: bool = False,
     ) -> bool:
         """SearchStrategy protocol — accept if improving in the given direction."""
         if direction is Direction.HIGHER_IS_BETTER:

--- a/anneal/engine/types.py
+++ b/anneal/engine/types.py
@@ -83,6 +83,10 @@ class AgentConfig(BaseModel):
     exploration_ratio: Literal["adaptive", "fixed"] | float = "adaptive"
     two_phase_mutation: bool = False
     diagnosis_model: str = ""
+    stall_timeout_seconds: int = Field(default=300, ge=0)
+    max_transient_retries: int = Field(default=3, ge=0)
+    transient_retry_base_seconds: float = Field(default=10.0, ge=0)
+    transient_retry_cap_seconds: float = Field(default=300.0, ge=0)
 
 
 class DeterministicEval(BaseModel):

--- a/anneal/eval_protocol.py
+++ b/anneal/eval_protocol.py
@@ -116,7 +116,7 @@ class _FunctionEvaluator:
         self._fn = fn
 
     def evaluate(self, artifact_path: str) -> EvalResult:
-        result = self._fn(artifact_path)  # type: ignore[call-arg]
+        result = self._fn(artifact_path)
         if not isinstance(result, EvalResult):
             raise TypeError(
                 f"Evaluator function must return EvalResult, got {type(result).__name__}"
@@ -229,5 +229,5 @@ def _load_module_from_file(file_path: str) -> object:
         raise ImportError(f"Cannot load module from file: {file_path}")
 
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    spec.loader.exec_module(module)
     return module

--- a/anneal/mcp_server.py
+++ b/anneal/mcp_server.py
@@ -18,7 +18,10 @@ from anneal.engine.knowledge import KnowledgeStore
 from anneal.engine.registry import Registry
 from anneal.engine.runner import RunLoopState
 
-mcp = FastMCP("anneal", instructions="Autonomous optimization engine for code, configs, and prompts.")
+mcp = FastMCP(
+    "anneal",
+    instructions="Autonomous optimization engine for code, configs, and prompts.",
+)
 
 
 def _find_repo_root() -> Path:
@@ -30,7 +33,7 @@ def _find_repo_root() -> Path:
     raise FileNotFoundError("No .anneal/ directory found. Run 'anneal init' first.")
 
 
-@mcp.tool()
+@mcp.tool()  # type: ignore[untyped-decorator]
 def anneal_status(target_id: str) -> str:
     """Get current status for an optimization target.
 
@@ -49,19 +52,22 @@ def anneal_status(target_id: str) -> str:
     loop_path = Path(target.knowledge_path) / ".loop-state.json"
     loop = RunLoopState.load(loop_path)
 
-    return json.dumps({
-        "target_id": target.id,
-        "runner_state": status_data.get("state", "UNKNOWN"),
-        "baseline_score": target.baseline_score,
-        "current_score": status_data.get("last_score", target.baseline_score),
-        "total_experiments": loop.total_experiments,
-        "kept_count": loop.kept_count,
-        "total_cost_usd": loop.cumulative_cost_usd,
-        "eval_mode": target.eval_mode.value,
-    }, indent=2)
+    return json.dumps(
+        {
+            "target_id": target.id,
+            "runner_state": status_data.get("state", "UNKNOWN"),
+            "baseline_score": target.baseline_score,
+            "current_score": status_data.get("last_score", target.baseline_score),
+            "total_experiments": loop.total_experiments,
+            "kept_count": loop.kept_count,
+            "total_cost_usd": loop.cumulative_cost_usd,
+            "eval_mode": target.eval_mode.value,
+        },
+        indent=2,
+    )
 
 
-@mcp.tool()
+@mcp.tool()  # type: ignore[untyped-decorator]
 def anneal_history(target_id: str, limit: int = 10) -> str:
     """Get recent experiment records for a target.
 
@@ -74,35 +80,41 @@ def anneal_history(target_id: str, limit: int = 10) -> str:
     knowledge = KnowledgeStore(repo_root / target.knowledge_path)
     records = knowledge.load_records(limit=limit)
 
-    return json.dumps([
-        {
-            "id": r.id,
-            "outcome": r.outcome.value,
-            "score": r.score,
-            "hypothesis": r.hypothesis,
-            "git_sha": r.git_sha,
-            "cost_usd": r.cost_usd,
-            "duration_seconds": r.duration_seconds,
-        }
-        for r in records
-    ], indent=2)
+    return json.dumps(
+        [
+            {
+                "id": r.id,
+                "outcome": r.outcome.value,
+                "score": r.score,
+                "hypothesis": r.hypothesis,
+                "git_sha": r.git_sha,
+                "cost_usd": r.cost_usd,
+                "duration_seconds": r.duration_seconds,
+            }
+            for r in records
+        ],
+        indent=2,
+    )
 
 
-@mcp.tool()
+@mcp.tool()  # type: ignore[untyped-decorator]
 def anneal_list_targets() -> str:
     """List all registered optimization targets."""
     repo_root = _find_repo_root()
     registry = Registry(repo_root)
 
-    return json.dumps([
-        {
-            "id": t.id,
-            "eval_mode": t.eval_mode.value,
-            "baseline_score": t.baseline_score,
-            "worktree": t.worktree_path,
-        }
-        for t in registry.all_targets()
-    ], indent=2)
+    return json.dumps(
+        [
+            {
+                "id": t.id,
+                "eval_mode": t.eval_mode.value,
+                "baseline_score": t.baseline_score,
+                "worktree": t.worktree_path,
+            }
+            for t in registry.all_targets()
+        ],
+        indent=2,
+    )
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,29 @@ dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=6.0",
+    "mypy>=1.13",
+    "ruff>=0.13",
+    "types-PyYAML>=6.0",
 ]
+
+[tool.mypy]
+python_version = "3.12"
+
+[[tool.mypy.overrides]]
+module = [
+    "tomli_w",
+    "scipy",
+    "scipy.*",
+    "tiktoken",
+    "sklearn",
+    "sklearn.*",
+    "sentence_transformers",
+    "mcp",
+    "mcp.*",
+    "aiohttp",
+    "aiohttp.*",
+]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/test_agent_coverage.py
+++ b/tests/test_agent_coverage.py
@@ -87,7 +87,40 @@ def _mock_openai_response(
     return response
 
 
-def _make_experiment_record(*, hypothesis: str = "test", score: float = 0.5) -> ExperimentRecord:
+def _make_streaming_proc(
+    stdout: bytes = b'{"result":"ok","total_cost_usd":0.01,"usage":{"input_tokens":10,"output_tokens":5}}',
+    returncode: int = 0,
+    stderr: bytes = b"",
+) -> MagicMock:
+    """Build a MagicMock subprocess that satisfies the streaming contract
+    used by ``AgentInvoker._run_with_stall_detection``: stdin is a
+    writable+drainable pipe, stdout/stderr yield their bytes on the first
+    read and EOF (empty bytes) thereafter, and ``wait()`` returns the
+    pre-set returncode immediately.
+    """
+
+    def _reader(payload: bytes) -> AsyncMock:
+        chunks = iter([payload, b""])
+        reader = AsyncMock()
+        reader.read = AsyncMock(side_effect=lambda _n=4096: next(chunks, b""))
+        return reader
+
+    proc = MagicMock()
+    proc.pid = 12345
+    proc.returncode = returncode
+    proc.stdin = MagicMock()
+    proc.stdin.drain = AsyncMock(return_value=None)
+    proc.stdout = _reader(stdout)
+    proc.stderr = _reader(stderr)
+    proc.wait = AsyncMock(return_value=returncode)
+    # Legacy callers (older tests) may still reference communicate.
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    return proc
+
+
+def _make_experiment_record(
+    *, hypothesis: str = "test", score: float = 0.5
+) -> ExperimentRecord:
     import datetime
 
     return ExperimentRecord(
@@ -130,7 +163,9 @@ class TestExtractHypothesis:
         # Assert
         assert result == "This is the hypothesis."
 
-    def test_extract_hypothesis_blank_line_before_next_header_captures_next_section(self) -> None:
+    def test_extract_hypothesis_blank_line_before_next_header_captures_next_section(
+        self,
+    ) -> None:
         # Arrange — the \s* in the regex consumes blank lines after the header,
         # so the capture group starts at the next ## section when hypothesis body is blank.
         # This verifies the actual (not idealized) regex behavior.
@@ -189,7 +224,9 @@ class TestExtractTags:
         # Assert
         assert result == ["foo", "bar", "baz"]
 
-    def test_extract_tags_blank_line_before_next_header_captures_next_section(self) -> None:
+    def test_extract_tags_blank_line_before_next_header_captures_next_section(
+        self,
+    ) -> None:
         # Arrange — same regex behavior: \s* in the pattern eats the blank line,
         # capture group starts at the next ## header text.
         text = "## Tags\n\n## Next"
@@ -280,11 +317,19 @@ class TestInvokeDispatch:
         invoker = AgentInvoker()
         config = _api_config()
         expected = AgentInvocationResult(
-            success=True, cost_usd=0.01, input_tokens=10, output_tokens=5,
-            hypothesis=None, hypothesis_source="synthesized", tags=[], raw_output="x",
+            success=True,
+            cost_usd=0.01,
+            input_tokens=10,
+            output_tokens=5,
+            hypothesis=None,
+            hypothesis_source="synthesized",
+            tags=[],
+            raw_output="x",
         )
 
-        with patch.object(invoker, "_invoke_api", new=AsyncMock(return_value=expected)) as mock_api:
+        with patch.object(
+            invoker, "_invoke_api", new=AsyncMock(return_value=expected)
+        ) as mock_api:
             # Act
             result = await invoker.invoke(config, "prompt", tmp_path, 60)
 
@@ -322,16 +367,26 @@ class TestInvokeDispatch:
             await invoker.invoke_meta(config, "meta prompt", tmp_path, 60, program_md)
 
     @pytest.mark.asyncio
-    async def test_invoke_claude_code_mode_calls_invoke_claude_code(self, tmp_path: Path) -> None:
+    async def test_invoke_claude_code_mode_calls_invoke_claude_code(
+        self, tmp_path: Path
+    ) -> None:
         # Arrange
         invoker = AgentInvoker()
         config = _cc_config()
         expected = AgentInvocationResult(
-            success=True, cost_usd=0.01, input_tokens=10, output_tokens=5,
-            hypothesis=None, hypothesis_source="synthesized", tags=[], raw_output="x",
+            success=True,
+            cost_usd=0.01,
+            input_tokens=10,
+            output_tokens=5,
+            hypothesis=None,
+            hypothesis_source="synthesized",
+            tags=[],
+            raw_output="x",
         )
 
-        with patch.object(invoker, "_invoke_claude_code", new=AsyncMock(return_value=expected)) as mock_cc:
+        with patch.object(
+            invoker, "_invoke_claude_code", new=AsyncMock(return_value=expected)
+        ) as mock_cc:
             # Act
             result = await invoker.invoke(config, "prompt", tmp_path, 60)
 
@@ -340,16 +395,26 @@ class TestInvokeDispatch:
         assert result is expected
 
     @pytest.mark.asyncio
-    async def test_invoke_deployment_delegates_to_invoke_with_deployment_mode(self, tmp_path: Path) -> None:
+    async def test_invoke_deployment_delegates_to_invoke_with_deployment_mode(
+        self, tmp_path: Path
+    ) -> None:
         # Arrange
         invoker = AgentInvoker()
         config = _cc_config()
         expected = AgentInvocationResult(
-            success=True, cost_usd=0.01, input_tokens=10, output_tokens=5,
-            hypothesis=None, hypothesis_source="synthesized", tags=[], raw_output="x",
+            success=True,
+            cost_usd=0.01,
+            input_tokens=10,
+            output_tokens=5,
+            hypothesis=None,
+            hypothesis_source="synthesized",
+            tags=[],
+            raw_output="x",
         )
 
-        with patch.object(invoker, "_invoke_claude_code", new=AsyncMock(return_value=expected)) as mock_cc:
+        with patch.object(
+            invoker, "_invoke_claude_code", new=AsyncMock(return_value=expected)
+        ) as mock_cc:
             # Act
             result = await invoker.invoke_deployment(config, "prompt", tmp_path, 60)
 
@@ -359,20 +424,32 @@ class TestInvokeDispatch:
         assert result is expected
 
     @pytest.mark.asyncio
-    async def test_invoke_meta_claude_code_mode_calls_invoke_claude_code(self, tmp_path: Path) -> None:
+    async def test_invoke_meta_claude_code_mode_calls_invoke_claude_code(
+        self, tmp_path: Path
+    ) -> None:
         # Arrange
         invoker = AgentInvoker()
         config = _cc_config()
         program_md = tmp_path / "program.md"
         program_md.write_text("strategy text")
         expected = AgentInvocationResult(
-            success=True, cost_usd=0.01, input_tokens=10, output_tokens=5,
-            hypothesis=None, hypothesis_source="synthesized", tags=[], raw_output="x",
+            success=True,
+            cost_usd=0.01,
+            input_tokens=10,
+            output_tokens=5,
+            hypothesis=None,
+            hypothesis_source="synthesized",
+            tags=[],
+            raw_output="x",
         )
 
-        with patch.object(invoker, "_invoke_claude_code", new=AsyncMock(return_value=expected)) as mock_cc:
+        with patch.object(
+            invoker, "_invoke_claude_code", new=AsyncMock(return_value=expected)
+        ) as mock_cc:
             # Act
-            result = await invoker.invoke_meta(config, "meta prompt", tmp_path, 60, program_md)
+            result = await invoker.invoke_meta(
+                config, "meta prompt", tmp_path, 60, program_md
+            )
 
         # Assert: meta_mode=True must be passed through
         _, kwargs = mock_cc.call_args
@@ -387,13 +464,23 @@ class TestInvokeDispatch:
         program_md = tmp_path / "program.md"
         program_md.write_text("strategy text")
         expected = AgentInvocationResult(
-            success=True, cost_usd=0.01, input_tokens=10, output_tokens=5,
-            hypothesis=None, hypothesis_source="synthesized", tags=[], raw_output="x",
+            success=True,
+            cost_usd=0.01,
+            input_tokens=10,
+            output_tokens=5,
+            hypothesis=None,
+            hypothesis_source="synthesized",
+            tags=[],
+            raw_output="x",
         )
 
-        with patch.object(invoker, "_invoke_api", new=AsyncMock(return_value=expected)) as mock_api:
+        with patch.object(
+            invoker, "_invoke_api", new=AsyncMock(return_value=expected)
+        ) as mock_api:
             # Act
-            result = await invoker.invoke_meta(config, "meta prompt", tmp_path, 60, program_md)
+            result = await invoker.invoke_meta(
+                config, "meta prompt", tmp_path, 60, program_md
+            )
 
         # Assert
         mock_api.assert_awaited_once()
@@ -412,11 +499,7 @@ class TestInvokeClaudeCodeAllowedTools:
         returncode: int = 0,
         stderr: bytes = b"",
     ) -> MagicMock:
-        proc = MagicMock()
-        proc.pid = 12345
-        proc.returncode = returncode
-        proc.communicate = AsyncMock(return_value=(stdout, stderr))
-        return proc
+        return _make_streaming_proc(stdout=stdout, returncode=returncode, stderr=stderr)
 
     @pytest.mark.asyncio
     async def test_meta_mode_uses_edit_tool(self, tmp_path: Path) -> None:
@@ -425,7 +508,9 @@ class TestInvokeClaudeCodeAllowedTools:
         config = _cc_config()
         proc = self._make_proc()
 
-        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)) as mock_exec:
+        with patch(
+            "asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)
+        ) as mock_exec:
             # Act
             await invoker._invoke_claude_code(
                 config, "prompt", tmp_path, 60, meta_mode=True
@@ -443,7 +528,9 @@ class TestInvokeClaudeCodeAllowedTools:
         config = _cc_config()
         proc = self._make_proc()
 
-        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)) as mock_exec:
+        with patch(
+            "asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)
+        ) as mock_exec:
             # Act
             await invoker._invoke_claude_code(
                 config, "prompt", tmp_path, 60, deployment_mode=True
@@ -461,7 +548,9 @@ class TestInvokeClaudeCodeAllowedTools:
         config = _cc_config()
         proc = self._make_proc()
 
-        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)) as mock_exec:
+        with patch(
+            "asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)
+        ) as mock_exec:
             # Act
             await invoker._invoke_claude_code(config, "prompt", tmp_path, 60)
 
@@ -472,23 +561,37 @@ class TestInvokeClaudeCodeAllowedTools:
 
     @pytest.mark.asyncio
     async def test_timeout_raises_agent_timeout_error(self, tmp_path: Path) -> None:
+        """Wall-clock exhaustion now surfaces from
+        :meth:`AgentInvoker._run_with_stall_detection`. Patch that helper
+        so the test stays focused on error propagation rather than the
+        streaming machinery (which is covered in
+        ``test_agent_stall_detection.py``).
+        """
         # Arrange
         invoker = AgentInvoker()
         config = _cc_config()
-        proc = MagicMock()
-        proc.pid = 99999
-        proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+        proc = _make_streaming_proc()
 
         with (
             patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)),
-            patch("os.killpg", side_effect=ProcessLookupError),
+            patch.object(
+                invoker,
+                "_run_with_stall_detection",
+                new=AsyncMock(
+                    side_effect=AgentTimeoutError(
+                        "Agent exceeded wall-clock budget of 1s"
+                    )
+                ),
+            ),
         ):
             # Act / Assert
-            with pytest.raises(AgentTimeoutError, match="exceeded time budget"):
+            with pytest.raises(AgentTimeoutError, match="wall-clock budget"):
                 await invoker._invoke_claude_code(config, "prompt", tmp_path, 1)
 
     @pytest.mark.asyncio
-    async def test_nonzero_returncode_raises_invocation_error(self, tmp_path: Path) -> None:
+    async def test_nonzero_returncode_raises_invocation_error(
+        self, tmp_path: Path
+    ) -> None:
         # Arrange
         invoker = AgentInvoker()
         config = _cc_config()
@@ -520,11 +623,13 @@ class TestInvokeClaudeCodeAllowedTools:
         # Arrange
         invoker = AgentInvoker()
         config = _cc_config()
-        payload = json.dumps({
-            "is_error": False,
-            "subtype": "error_overloaded",
-            "total_cost_usd": 0.002,
-        }).encode()
+        payload = json.dumps(
+            {
+                "is_error": False,
+                "subtype": "error_overloaded",
+                "total_cost_usd": 0.002,
+            }
+        ).encode()
         proc = self._make_proc(stdout=payload)
 
         with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)):
@@ -537,28 +642,36 @@ class TestInvokeClaudeCodeAllowedTools:
         # Arrange
         invoker = AgentInvoker()
         config = _cc_config()
-        payload = json.dumps({
-            "is_error": True,
-            "subtype": "",
-            "total_cost_usd": 0.0,
-        }).encode()
+        payload = json.dumps(
+            {
+                "is_error": True,
+                "subtype": "",
+                "total_cost_usd": 0.0,
+            }
+        ).encode()
         proc = self._make_proc(stdout=payload)
 
         with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)):
             # Act / Assert
-            with pytest.raises(AgentInvocationError, match="Claude Code returned error"):
+            with pytest.raises(
+                AgentInvocationError, match="Claude Code returned error"
+            ):
                 await invoker._invoke_claude_code(config, "prompt", tmp_path, 60)
 
     @pytest.mark.asyncio
-    async def test_success_response_returns_invocation_result(self, tmp_path: Path) -> None:
+    async def test_success_response_returns_invocation_result(
+        self, tmp_path: Path
+    ) -> None:
         # Arrange
         invoker = AgentInvoker()
         config = _cc_config()
-        payload = json.dumps({
-            "result": "## Hypothesis\nFix the thing.\n## Tags\nfix, quality",
-            "total_cost_usd": 0.015,
-            "usage": {"input_tokens": 200, "output_tokens": 80},
-        }).encode()
+        payload = json.dumps(
+            {
+                "result": "## Hypothesis\nFix the thing.\n## Tags\nfix, quality",
+                "total_cost_usd": 0.015,
+                "usage": {"input_tokens": 200, "output_tokens": 80},
+            }
+        ).encode()
         proc = self._make_proc(stdout=payload)
 
         with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)):
@@ -612,11 +725,15 @@ class TestInvokeApi:
         assert result.output_tokens == 60
 
     @pytest.mark.asyncio
-    async def test_invoke_api_no_hypothesis_synthesized_source(self, tmp_path: Path) -> None:
+    async def test_invoke_api_no_hypothesis_synthesized_source(
+        self, tmp_path: Path
+    ) -> None:
         # Arrange
         invoker = AgentInvoker()
         config = _api_config()
-        mock_response = _mock_openai_response("Plain text with no headers.", prompt_tokens=50, completion_tokens=20)
+        mock_response = _mock_openai_response(
+            "Plain text with no headers.", prompt_tokens=50, completion_tokens=20
+        )
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
@@ -634,23 +751,31 @@ class TestInvokeApi:
         assert result.tags == []
 
     @pytest.mark.asyncio
-    async def test_invoke_api_timeout_raises_agent_timeout_error(self, tmp_path: Path) -> None:
+    async def test_invoke_api_timeout_raises_agent_timeout_error(
+        self, tmp_path: Path
+    ) -> None:
         # Arrange
         invoker = AgentInvoker()
         config = _api_config()
         mock_client = AsyncMock()
-        mock_client.chat.completions.create = AsyncMock(side_effect=asyncio.TimeoutError())
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=asyncio.TimeoutError()
+        )
 
         with (
             patch("anneal.engine.agent.make_client", return_value=mock_client),
             patch("anneal.engine.agent.strip_provider_prefix", return_value="gpt-4.1"),
         ):
             # Act / Assert
-            with pytest.raises(AgentTimeoutError, match="API agent exceeded time budget"):
+            with pytest.raises(
+                AgentTimeoutError, match="API agent exceeded time budget"
+            ):
                 await invoker._invoke_api(config, "prompt", tmp_path, 1)
 
     @pytest.mark.asyncio
-    async def test_invoke_api_null_usage_defaults_to_zero_tokens(self, tmp_path: Path) -> None:
+    async def test_invoke_api_null_usage_defaults_to_zero_tokens(
+        self, tmp_path: Path
+    ) -> None:
         # Arrange
         invoker = AgentInvoker()
         config = _api_config()
@@ -673,7 +798,9 @@ class TestInvokeApi:
         mock_cost.assert_called_once_with(config.model, 0, 0)
 
     @pytest.mark.asyncio
-    async def test_invoke_api_null_content_returns_empty_raw_output(self, tmp_path: Path) -> None:
+    async def test_invoke_api_null_content_returns_empty_raw_output(
+        self, tmp_path: Path
+    ) -> None:
         # Arrange
         invoker = AgentInvoker()
         config = _api_config()
@@ -804,24 +931,32 @@ class TestBuildDiagnosisPrompt:
 
 class TestDiagnoseApiErrorHandling:
     @pytest.mark.asyncio
-    async def test_diagnose_timeout_raises_agent_timeout_error(self, tmp_path: Path) -> None:
+    async def test_diagnose_timeout_raises_agent_timeout_error(
+        self, tmp_path: Path
+    ) -> None:
         # Arrange
         invoker = AgentInvoker()
         config = _api_config()
         eval_result = EvalResult(score=0.5)
         mock_client = AsyncMock()
-        mock_client.chat.completions.create = AsyncMock(side_effect=asyncio.TimeoutError())
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=asyncio.TimeoutError()
+        )
 
         with (
             patch("anneal.engine.agent.make_client", return_value=mock_client),
             patch("anneal.engine.agent.strip_provider_prefix", return_value="gpt-4.1"),
         ):
             # Act / Assert
-            with pytest.raises(AgentTimeoutError, match="Diagnosis agent exceeded 60s timeout"):
+            with pytest.raises(
+                AgentTimeoutError, match="Diagnosis agent exceeded 60s timeout"
+            ):
                 await invoker.diagnose(config, "artifact", eval_result, [], tmp_path)
 
     @pytest.mark.asyncio
-    async def test_diagnose_generic_exception_raises_invocation_error(self, tmp_path: Path) -> None:
+    async def test_diagnose_generic_exception_raises_invocation_error(
+        self, tmp_path: Path
+    ) -> None:
         # Arrange
         invoker = AgentInvoker()
         config = _api_config()
@@ -861,7 +996,9 @@ class TestDiagnoseApiErrorHandling:
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         with (
-            patch("anneal.engine.agent.make_client", return_value=mock_client) as mock_make,
+            patch(
+                "anneal.engine.agent.make_client", return_value=mock_client
+            ) as mock_make,
             patch("anneal.engine.agent.compute_cost", return_value=0.0),
             patch("anneal.engine.agent.strip_provider_prefix", side_effect=lambda m: m),
         ):
@@ -968,15 +1105,25 @@ class TestGenerateDraftsApiMode:
         invoker = AgentInvoker()
         config = _api_config(temperature=0.7, max_budget_usd=0.30)
         mock_result = AgentInvocationResult(
-            success=True, cost_usd=0.01, input_tokens=10, output_tokens=5,
-            hypothesis="h", hypothesis_source="agent", tags=[], raw_output="draft output",
+            success=True,
+            cost_usd=0.01,
+            input_tokens=10,
+            output_tokens=5,
+            hypothesis="h",
+            hypothesis_source="agent",
+            tags=[],
+            raw_output="draft output",
         )
         git = AsyncMock()
         git.rev_parse = AsyncMock(return_value="sha123")
 
-        with patch.object(invoker, "_invoke_api", new=AsyncMock(return_value=mock_result)):
+        with patch.object(
+            invoker, "_invoke_api", new=AsyncMock(return_value=mock_result)
+        ):
             # Act
-            drafts = await invoker.generate_drafts(config, "prompt", tmp_path, 60, n_drafts=3, git=git)
+            drafts = await invoker.generate_drafts(
+                config, "prompt", tmp_path, 60, n_drafts=3, git=git
+            )
 
         # Assert
         assert len(drafts) == 3
@@ -985,20 +1132,30 @@ class TestGenerateDraftsApiMode:
             assert diff == "draft output"
 
     @pytest.mark.asyncio
-    async def test_generate_drafts_api_skips_failed_drafts(self, tmp_path: Path) -> None:
+    async def test_generate_drafts_api_skips_failed_drafts(
+        self, tmp_path: Path
+    ) -> None:
         # Arrange
         invoker = AgentInvoker()
         config = _api_config(temperature=0.7, max_budget_usd=0.30)
         good_result = AgentInvocationResult(
-            success=True, cost_usd=0.01, input_tokens=10, output_tokens=5,
-            hypothesis="h", hypothesis_source="agent", tags=[], raw_output="good",
+            success=True,
+            cost_usd=0.01,
+            input_tokens=10,
+            output_tokens=5,
+            hypothesis="h",
+            hypothesis_source="agent",
+            tags=[],
+            raw_output="good",
         )
         git = AsyncMock()
         git.rev_parse = AsyncMock(return_value="sha123")
 
         call_count = 0
 
-        async def _sometimes_fail(config: AgentConfig, *args: object, **kwargs: object) -> AgentInvocationResult:
+        async def _sometimes_fail(
+            config: AgentConfig, *args: object, **kwargs: object
+        ) -> AgentInvocationResult:
             nonlocal call_count
             call_count += 1
             if call_count == 2:
@@ -1007,7 +1164,9 @@ class TestGenerateDraftsApiMode:
 
         with patch.object(invoker, "_invoke_api", new=_sometimes_fail):
             # Act
-            drafts = await invoker.generate_drafts(config, "prompt", tmp_path, 60, n_drafts=3, git=git)
+            drafts = await invoker.generate_drafts(
+                config, "prompt", tmp_path, 60, n_drafts=3, git=git
+            )
 
         # Assert: only 2 successful drafts returned
         assert len(drafts) == 2
@@ -1019,11 +1178,19 @@ class TestGenerateDraftsApiMode:
         config = _api_config(temperature=0.7, max_budget_usd=0.30)
         captured_configs: list[AgentConfig] = []
         mock_result = AgentInvocationResult(
-            success=True, cost_usd=0.01, input_tokens=10, output_tokens=5,
-            hypothesis=None, hypothesis_source="synthesized", tags=[], raw_output="x",
+            success=True,
+            cost_usd=0.01,
+            input_tokens=10,
+            output_tokens=5,
+            hypothesis=None,
+            hypothesis_source="synthesized",
+            tags=[],
+            raw_output="x",
         )
 
-        async def _capture(cfg: AgentConfig, *args: object, **kwargs: object) -> AgentInvocationResult:
+        async def _capture(
+            cfg: AgentConfig, *args: object, **kwargs: object
+        ) -> AgentInvocationResult:
             captured_configs.append(cfg)
             return mock_result
 
@@ -1032,7 +1199,9 @@ class TestGenerateDraftsApiMode:
 
         with patch.object(invoker, "_invoke_api", new=_capture):
             # Act
-            await invoker.generate_drafts(config, "prompt", tmp_path, 60, n_drafts=3, git=git)
+            await invoker.generate_drafts(
+                config, "prompt", tmp_path, 60, n_drafts=3, git=git
+            )
 
         # Assert: temperatures differ across drafts
         temps = [c.temperature for c in captured_configs]
@@ -1050,28 +1219,29 @@ class TestGenerateDraftsClaudeCodeMode:
         stdout: bytes = b'{"result":"ok","total_cost_usd":0.01,"usage":{"input_tokens":10,"output_tokens":5}}',
         returncode: int = 0,
     ) -> MagicMock:
-        proc = MagicMock()
-        proc.pid = 1
-        proc.returncode = returncode
-        proc.communicate = AsyncMock(return_value=(stdout, b""))
-        return proc
+        return _make_streaming_proc(stdout=stdout, returncode=returncode)
 
     @pytest.mark.asyncio
     async def test_generate_drafts_cc_returns_diffs(self, tmp_path: Path) -> None:
-        # Arrange
+        # Arrange — factory so each subprocess invocation gets fresh stream
+        # readers (they're single-shot AsyncMock side_effect iterators).
         invoker = AgentInvoker()
         config = _cc_config()
         config = config.model_copy(update={"max_budget_usd": 0.30})
-        proc = self._make_proc()
         git = AsyncMock()
         git.rev_parse = AsyncMock(return_value="sha123")
         git.capture_diff = AsyncMock(return_value="--- diff ---")
         git.reset_hard = AsyncMock()
         git.clean_untracked = AsyncMock()
 
-        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)):
+        async def _spawn(*_args: object, **_kwargs: object) -> MagicMock:
+            return _make_streaming_proc()
+
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(side_effect=_spawn)):
             # Act
-            drafts = await invoker.generate_drafts(config, "prompt", tmp_path, 60, n_drafts=2, git=git)
+            drafts = await invoker.generate_drafts(
+                config, "prompt", tmp_path, 60, n_drafts=2, git=git
+            )
 
         # Assert
         assert len(drafts) == 2
@@ -1079,28 +1249,36 @@ class TestGenerateDraftsClaudeCodeMode:
             assert diff == "--- diff ---"
 
     @pytest.mark.asyncio
-    async def test_generate_drafts_cc_resets_worktree_between_drafts(self, tmp_path: Path) -> None:
+    async def test_generate_drafts_cc_resets_worktree_between_drafts(
+        self, tmp_path: Path
+    ) -> None:
         # Arrange
         invoker = AgentInvoker()
         config = _cc_config()
         config = config.model_copy(update={"max_budget_usd": 0.30})
-        proc = self._make_proc()
         git = AsyncMock()
         git.rev_parse = AsyncMock(return_value="sha123")
         git.capture_diff = AsyncMock(return_value="diff")
         git.reset_hard = AsyncMock()
         git.clean_untracked = AsyncMock()
 
-        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)):
+        async def _spawn(*_args: object, **_kwargs: object) -> MagicMock:
+            return _make_streaming_proc()
+
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(side_effect=_spawn)):
             # Act
-            await invoker.generate_drafts(config, "prompt", tmp_path, 60, n_drafts=3, git=git)
+            await invoker.generate_drafts(
+                config, "prompt", tmp_path, 60, n_drafts=3, git=git
+            )
 
         # Assert: reset_hard and clean_untracked called once per draft
         assert git.reset_hard.await_count == 3
         assert git.clean_untracked.await_count == 3
 
     @pytest.mark.asyncio
-    async def test_generate_drafts_cc_skips_failed_draft_and_still_resets(self, tmp_path: Path) -> None:
+    async def test_generate_drafts_cc_skips_failed_draft_and_still_resets(
+        self, tmp_path: Path
+    ) -> None:
         # Arrange
         invoker = AgentInvoker()
         config = _cc_config()
@@ -1113,26 +1291,38 @@ class TestGenerateDraftsClaudeCodeMode:
 
         call_count = 0
 
-        async def _sometimes_fail(cfg: AgentConfig, *args: object, **kwargs: object) -> AgentInvocationResult:
+        async def _sometimes_fail(
+            cfg: AgentConfig, *args: object, **kwargs: object
+        ) -> AgentInvocationResult:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
                 raise AgentInvocationError("first draft failed")
             return AgentInvocationResult(
-                success=True, cost_usd=0.01, input_tokens=10, output_tokens=5,
-                hypothesis=None, hypothesis_source="synthesized", tags=[], raw_output="ok",
+                success=True,
+                cost_usd=0.01,
+                input_tokens=10,
+                output_tokens=5,
+                hypothesis=None,
+                hypothesis_source="synthesized",
+                tags=[],
+                raw_output="ok",
             )
 
         with patch.object(invoker, "_invoke_claude_code", new=_sometimes_fail):
             # Act
-            drafts = await invoker.generate_drafts(config, "prompt", tmp_path, 60, n_drafts=2, git=git)
+            drafts = await invoker.generate_drafts(
+                config, "prompt", tmp_path, 60, n_drafts=2, git=git
+            )
 
         # Assert: only 1 successful draft; reset still happened for both
         assert len(drafts) == 1
         assert git.reset_hard.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_generate_drafts_cc_timeout_error_skips_draft(self, tmp_path: Path) -> None:
+    async def test_generate_drafts_cc_timeout_error_skips_draft(
+        self, tmp_path: Path
+    ) -> None:
         # Arrange
         invoker = AgentInvoker()
         config = _cc_config()
@@ -1144,11 +1334,14 @@ class TestGenerateDraftsClaudeCodeMode:
         git.clean_untracked = AsyncMock()
 
         with patch.object(
-            invoker, "_invoke_claude_code",
+            invoker,
+            "_invoke_claude_code",
             new=AsyncMock(side_effect=AgentTimeoutError("timed out")),
         ):
             # Act
-            drafts = await invoker.generate_drafts(config, "prompt", tmp_path, 60, n_drafts=2, git=git)
+            drafts = await invoker.generate_drafts(
+                config, "prompt", tmp_path, 60, n_drafts=2, git=git
+            )
 
         # Assert: all drafts failed, but resets still happened
         assert len(drafts) == 0

--- a/tests/test_agent_retry_classification.py
+++ b/tests/test_agent_retry_classification.py
@@ -1,0 +1,363 @@
+"""Tests for transient/structural failure classification (RH.2).
+
+Covers:
+  - ``_classify_api_exception`` rule table (HTTP statuses, network, JSON, timeout)
+  - ``_classify_subprocess_failure`` stderr substring rules
+  - Subclass relationships required for backward compatibility
+  - Runner-level transient retry loop in
+    :meth:`ExperimentRunner._invoke_with_transient_retries`
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from anneal.engine.agent import (
+    AgentInvocationError,
+    AgentInvoker,
+    AgentInvocationResult,
+    AgentStructuralError,
+    AgentTimeoutError,
+    AgentTransientError,
+    _classify_api_exception,
+    _classify_subprocess_failure,
+)
+from anneal.engine.runner import ExperimentRunner
+from anneal.engine.types import AgentConfig
+
+
+# ---------------------------------------------------------------------------
+# _classify_api_exception
+# ---------------------------------------------------------------------------
+
+
+class _HttpError(Exception):
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"HTTP {status_code}")
+        self.status_code = status_code
+
+
+class _ResponseHttpError(Exception):
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"HTTP {status_code}")
+        self.response = SimpleNamespace(status_code=status_code)
+
+
+@pytest.mark.parametrize("status", [408, 425, 429, 500, 502, 503, 504])
+def test_classify_transient_http_status(status: int) -> None:
+    assert _classify_api_exception(_HttpError(status)) is AgentTransientError
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 422])
+def test_classify_structural_http_status(status: int) -> None:
+    assert _classify_api_exception(_HttpError(status)) is AgentStructuralError
+
+
+def test_classify_status_via_response_attribute() -> None:
+    """Some SDKs surface status via ``exc.response.status_code`` rather than
+    a top-level attribute. Both shapes must classify identically.
+    """
+    assert _classify_api_exception(_ResponseHttpError(429)) is AgentTransientError
+    assert _classify_api_exception(_ResponseHttpError(401)) is AgentStructuralError
+
+
+def test_classify_timeout_transient() -> None:
+    assert _classify_api_exception(asyncio.TimeoutError()) is AgentTransientError
+
+
+def test_classify_jsondecode_transient() -> None:
+    exc = json.JSONDecodeError("expecting value", "", 0)
+    assert _classify_api_exception(exc) is AgentTransientError
+
+
+def test_classify_connection_error_transient() -> None:
+    assert _classify_api_exception(ConnectionResetError()) is AgentTransientError
+    assert _classify_api_exception(OSError("network down")) is AgentTransientError
+
+
+def test_classify_unknown_exception_structural() -> None:
+    """Unknown exception types default to structural — conservative bias
+    prevents silent infinite-retry loops on unrecognized failure modes.
+    """
+
+    class _Custom(Exception): ...
+
+    assert _classify_api_exception(_Custom("???")) is AgentStructuralError
+
+
+# ---------------------------------------------------------------------------
+# _classify_subprocess_failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stderr_text",
+    [
+        "Error: rate_limit exceeded",
+        "RATE LIMIT reached, slow down",
+        "anthropic.OverloadedError: overloaded_error",
+        "service_unavailable",
+        "connection reset by peer",
+        "read timed out after 30s",
+        "Bad gateway from upstream",
+    ],
+)
+def test_subprocess_known_transient_stderr(stderr_text: str) -> None:
+    assert _classify_subprocess_failure(stderr_text) is AgentTransientError
+
+
+@pytest.mark.parametrize(
+    "stderr_text",
+    [
+        "Authentication failed: invalid API key",
+        "Unknown flag: --foo",
+        "Permission denied",
+        "",
+        "Some other error nobody mapped yet",
+    ],
+)
+def test_subprocess_unknown_or_structural_stderr(stderr_text: str) -> None:
+    assert _classify_subprocess_failure(stderr_text) is AgentStructuralError
+
+
+# ---------------------------------------------------------------------------
+# Exception subclass invariants
+# ---------------------------------------------------------------------------
+
+
+def test_transient_is_subclass_of_invocation_error() -> None:
+    """Existing ``except AgentInvocationError`` sites in runner.py must
+    keep catching transient errors so behavior is additive."""
+    assert issubclass(AgentTransientError, AgentInvocationError)
+    assert issubclass(AgentStructuralError, AgentInvocationError)
+
+
+def test_structural_not_caught_by_timeout_handler() -> None:
+    """Sanity check: structural errors are NOT timeouts — runner's
+    Outcome.KILLED arm must not swallow them."""
+    assert not issubclass(AgentStructuralError, AgentTimeoutError)
+    assert not issubclass(AgentTransientError, AgentTimeoutError)
+
+
+# ---------------------------------------------------------------------------
+# Runner._invoke_with_transient_retries
+# ---------------------------------------------------------------------------
+
+
+def _agent_config(
+    *,
+    max_transient_retries: int = 3,
+    base: float = 0.0,
+    cap: float = 0.0,
+) -> AgentConfig:
+    return AgentConfig(
+        mode="api",
+        model="gpt-4.1",
+        evaluator_model="gpt-4.1-mini",
+        max_transient_retries=max_transient_retries,
+        transient_retry_base_seconds=base,
+        transient_retry_cap_seconds=cap,
+    )
+
+
+def _target(config: AgentConfig) -> Any:
+    return SimpleNamespace(
+        id="t-test",
+        agent_config=config,
+        time_budget_seconds=60,
+    )
+
+
+def _success_result() -> AgentInvocationResult:
+    return AgentInvocationResult(
+        success=True,
+        cost_usd=0.0,
+        input_tokens=0,
+        output_tokens=0,
+        hypothesis=None,
+        hypothesis_source="synthesized",
+        tags=[],
+        raw_output="",
+    )
+
+
+def _runner_with_agent(invoker: AgentInvoker) -> ExperimentRunner:
+    """Bypass __init__ — we only exercise one method that uses ``self._agent``
+    and ``logger``. Avoids dragging in registry/git/eval setup.
+    """
+    runner = ExperimentRunner.__new__(ExperimentRunner)
+    runner._agent = invoker  # type: ignore[attr-defined]
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_transient_retry_then_success() -> None:
+    """One transient error followed by success returns the success result
+    without surfacing as a CRASHED experiment."""
+    invoker = MagicMock(spec=AgentInvoker)
+    invoker.invoke = AsyncMock(
+        side_effect=[
+            AgentTransientError("429"),
+            _success_result(),
+        ]
+    )
+    runner = _runner_with_agent(invoker)
+    target = _target(_agent_config(max_transient_retries=3))
+
+    result = await runner._invoke_with_transient_retries(
+        target,
+        prompt="p",
+        worktree=Path("/tmp"),
+        deployment=False,
+    )
+    assert result.success is True
+    assert invoker.invoke.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_transient_exhaustion_promotes_to_structural() -> None:
+    """``max_transient_retries`` extra attempts; the (N+1)th transient
+    becomes a terminal :class:`AgentStructuralError` so the runner's
+    existing CRASHED arm handles it."""
+    invoker = MagicMock(spec=AgentInvoker)
+    invoker.invoke = AsyncMock(side_effect=AgentTransientError("429 always"))
+    runner = _runner_with_agent(invoker)
+    target = _target(_agent_config(max_transient_retries=2))
+
+    with pytest.raises(AgentStructuralError) as excinfo:
+        await runner._invoke_with_transient_retries(
+            target,
+            prompt="p",
+            worktree=Path("/tmp"),
+            deployment=False,
+        )
+    assert "Transient retries exhausted" in str(excinfo.value)
+    assert invoker.invoke.await_count == 3  # initial + 2 retries
+    assert isinstance(excinfo.value.__cause__, AgentTransientError)
+
+
+@pytest.mark.asyncio
+async def test_structural_error_no_retry() -> None:
+    """Structural errors are terminal — zero retries, original exception
+    propagates unchanged."""
+    invoker = MagicMock(spec=AgentInvoker)
+    invoker.invoke = AsyncMock(side_effect=AgentStructuralError("401"))
+    runner = _runner_with_agent(invoker)
+    target = _target(_agent_config(max_transient_retries=3))
+
+    with pytest.raises(AgentStructuralError, match="401"):
+        await runner._invoke_with_transient_retries(
+            target,
+            prompt="p",
+            worktree=Path("/tmp"),
+            deployment=False,
+        )
+    assert invoker.invoke.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_timeout_propagates_unwrapped() -> None:
+    """Wall-clock and stall timeouts skip the retry loop entirely — the
+    runner's KILLED arm must see them as :class:`AgentTimeoutError`."""
+    invoker = MagicMock(spec=AgentInvoker)
+    invoker.invoke = AsyncMock(side_effect=AgentTimeoutError("budget"))
+    runner = _runner_with_agent(invoker)
+    target = _target(_agent_config(max_transient_retries=3))
+
+    with pytest.raises(AgentTimeoutError):
+        await runner._invoke_with_transient_retries(
+            target,
+            prompt="p",
+            worktree=Path("/tmp"),
+            deployment=False,
+        )
+    assert invoker.invoke.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_max_retries_zero_reproduces_legacy_behavior() -> None:
+    """``max_transient_retries=0`` means a single attempt; transient
+    failures surface as structural immediately, matching pre-RH.2
+    semantics where every failure went straight to CRASHED."""
+    invoker = MagicMock(spec=AgentInvoker)
+    invoker.invoke = AsyncMock(side_effect=AgentTransientError("429"))
+    runner = _runner_with_agent(invoker)
+    target = _target(_agent_config(max_transient_retries=0))
+
+    with pytest.raises(AgentStructuralError):
+        await runner._invoke_with_transient_retries(
+            target,
+            prompt="p",
+            worktree=Path("/tmp"),
+            deployment=False,
+        )
+    assert invoker.invoke.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_deployment_path_uses_invoke_deployment() -> None:
+    """``deployment=True`` routes to ``invoke_deployment``; retry
+    semantics are identical."""
+    invoker = MagicMock(spec=AgentInvoker)
+    invoker.invoke_deployment = AsyncMock(
+        side_effect=[
+            AgentTransientError("503"),
+            _success_result(),
+        ]
+    )
+    runner = _runner_with_agent(invoker)
+    target = _target(_agent_config(max_transient_retries=3))
+
+    result = await runner._invoke_with_transient_retries(
+        target,
+        prompt="p",
+        worktree=Path("/tmp"),
+        deployment=True,
+    )
+    assert result.success is True
+    assert invoker.invoke_deployment.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_backoff_caps_at_configured_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exponential backoff respects ``transient_retry_cap_seconds`` so the
+    retry loop cannot starve the experiment slot indefinitely."""
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    invoker = MagicMock(spec=AgentInvoker)
+    invoker.invoke = AsyncMock(
+        side_effect=[
+            AgentTransientError("a"),
+            AgentTransientError("b"),
+            AgentTransientError("c"),
+            _success_result(),
+        ]
+    )
+    runner = _runner_with_agent(invoker)
+    target = _target(
+        _agent_config(max_transient_retries=5, base=10.0, cap=15.0),
+    )
+
+    await runner._invoke_with_transient_retries(
+        target,
+        prompt="p",
+        worktree=Path("/tmp"),
+        deployment=False,
+    )
+
+    # base=10, cap=15 → expected backoffs: 10, 15, 15
+    assert sleeps == [10.0, 15.0, 15.0]

--- a/tests/test_agent_stall_detection.py
+++ b/tests/test_agent_stall_detection.py
@@ -1,0 +1,231 @@
+"""Tests for AgentInvoker._run_with_stall_detection (RH.1).
+
+Exercises the activity-heartbeat watchdog with real bash subprocesses so
+the streaming + watchdog interaction is tested end-to-end rather than via
+mocks of asyncio internals. All subprocesses are bounded by short
+``time_budget`` and ``stall`` windows so the suite finishes in seconds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import time
+
+import pytest
+
+from anneal.engine.agent import (
+    AgentInvocationError,
+    AgentInvoker,
+    AgentStalledError,
+    AgentTimeoutError,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None,
+    reason="bash required to drive stall-detection subprocesses",
+)
+
+
+async def _spawn_bash(script: str) -> asyncio.subprocess.Process:
+    return await asyncio.create_subprocess_exec(
+        "bash",
+        "-c",
+        script,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_silent_subprocess_killed_at_stall_window() -> None:
+    """A subprocess that produces no output for longer than ``stall_seconds``
+    is killed via SIGKILL and surfaces as :class:`AgentStalledError`.
+    """
+    invoker = AgentInvoker()
+    proc = await _spawn_bash("sleep 30; echo done")
+
+    start = time.monotonic()
+    with pytest.raises(AgentStalledError):
+        await invoker._run_with_stall_detection(
+            proc,
+            prompt=b"",
+            wall_clock_seconds=20,
+            stall_seconds=1,
+        )
+    elapsed = time.monotonic() - start
+
+    # Detection happens within stall window + one watchdog tick (~stall/4).
+    assert elapsed < 5, f"stall detection too slow: {elapsed:.2f}s"
+    assert elapsed >= 1, f"stall detection fired before window: {elapsed:.2f}s"
+
+
+@pytest.mark.asyncio
+async def test_active_subprocess_runs_to_completion() -> None:
+    """A subprocess that emits a heartbeat well within ``stall_seconds``
+    completes normally without false-positive stalls.
+    """
+    invoker = AgentInvoker()
+    proc = await _spawn_bash(
+        "for i in 1 2 3 4; do echo tick-$i; sleep 0.2; done; exit 0"
+    )
+
+    stdout, stderr = await invoker._run_with_stall_detection(
+        proc,
+        prompt=b"",
+        wall_clock_seconds=10,
+        stall_seconds=2,
+    )
+    assert proc.returncode == 0
+    assert b"tick-1" in stdout and b"tick-4" in stdout
+    assert stderr == b""
+
+
+@pytest.mark.asyncio
+async def test_steady_activity_hits_wallclock() -> None:
+    """A subprocess that keeps emitting forever escapes the stall watchdog
+    but is killed by the wall-clock timeout via :class:`AgentTimeoutError`.
+    """
+    invoker = AgentInvoker()
+    proc = await _spawn_bash("while true; do echo .; sleep 0.05; done")
+
+    start = time.monotonic()
+    with pytest.raises(AgentTimeoutError) as excinfo:
+        await invoker._run_with_stall_detection(
+            proc,
+            prompt=b"",
+            wall_clock_seconds=1,
+            stall_seconds=10,
+        )
+    elapsed = time.monotonic() - start
+
+    # Stall watchdog must NOT fire here — wall-clock should
+    assert not isinstance(excinfo.value, AgentStalledError)
+    assert elapsed < 4, f"wall-clock enforcement too slow: {elapsed:.2f}s"
+
+
+@pytest.mark.asyncio
+async def test_stall_disabled_when_zero() -> None:
+    """``stall_seconds=0`` reproduces pre-RH.1 behavior — silent
+    subprocesses run until wall-clock or natural exit.
+    """
+    invoker = AgentInvoker()
+    proc = await _spawn_bash("sleep 0.5; echo woke")
+
+    stdout, _ = await invoker._run_with_stall_detection(
+        proc,
+        prompt=b"",
+        wall_clock_seconds=5,
+        stall_seconds=0,
+    )
+    assert proc.returncode == 0
+    assert b"woke" in stdout
+
+
+@pytest.mark.asyncio
+async def test_stdin_prompt_is_delivered() -> None:
+    """Streaming prompt write reaches the subprocess and round-trips."""
+    invoker = AgentInvoker()
+    proc = await _spawn_bash("cat")
+
+    stdout, _ = await invoker._run_with_stall_detection(
+        proc,
+        prompt=b"hello-from-test\n",
+        wall_clock_seconds=5,
+        stall_seconds=2,
+    )
+    assert proc.returncode == 0
+    assert stdout == b"hello-from-test\n"
+
+
+@pytest.mark.asyncio
+async def test_no_orphan_children_after_stall() -> None:
+    """SIGKILL on the process group leaves no descendants of the killed
+    subprocess. Verified by polling /proc-equivalent via ``ps``.
+    """
+    if shutil.which("ps") is None:
+        pytest.skip("ps required to verify orphan cleanup")
+
+    invoker = AgentInvoker()
+    proc = await _spawn_bash("sleep 60 & sleep 60")
+    pid = proc.pid
+
+    with pytest.raises(AgentStalledError):
+        await invoker._run_with_stall_detection(
+            proc,
+            prompt=b"",
+            wall_clock_seconds=10,
+            stall_seconds=1,
+        )
+
+    # Give the OS a brief moment to reap.
+    await asyncio.sleep(0.3)
+    res = await asyncio.create_subprocess_exec(
+        "ps",
+        "-o",
+        "pid=",
+        "-g",
+        str(pid),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    out, _ = await res.communicate()
+    survivors = [line for line in out.decode().split() if line.strip()]
+    assert not survivors, f"orphaned pids in group {pid}: {survivors}"
+
+
+@pytest.mark.asyncio
+async def test_stalled_error_is_timeout_subclass() -> None:
+    """Existing handlers that catch :class:`AgentTimeoutError` continue
+    to catch stalls without modification — required for runner-level
+    backward compatibility.
+    """
+    assert issubclass(AgentStalledError, AgentTimeoutError)
+    assert issubclass(AgentStalledError, AgentInvocationError)
+
+
+@pytest.mark.asyncio
+async def test_returncode_preserved_on_clean_exit() -> None:
+    """Non-zero exits without stderr-known transient signatures keep their
+    returncode visible to the caller (used by classification logic).
+    """
+    invoker = AgentInvoker()
+    proc = await _spawn_bash("echo out; echo err >&2; exit 3")
+
+    stdout, stderr = await invoker._run_with_stall_detection(
+        proc,
+        prompt=b"",
+        wall_clock_seconds=5,
+        stall_seconds=2,
+    )
+    assert proc.returncode == 3
+    assert b"out" in stdout
+    assert b"err" in stderr
+
+
+@pytest.mark.asyncio
+async def test_pid_dies_on_wallclock_kill() -> None:
+    """Wall-clock SIGKILL actually terminates the subprocess (not just
+    raises) — verified by ``waitpid``.
+    """
+    invoker = AgentInvoker()
+    proc = await _spawn_bash("sleep 30")
+    pid = proc.pid
+
+    with pytest.raises(AgentTimeoutError):
+        await invoker._run_with_stall_detection(
+            proc,
+            prompt=b"",
+            wall_clock_seconds=1,
+            stall_seconds=10,
+        )
+
+    # waitpid with WNOHANG returns (0, 0) if still alive; (pid, status) if reaped
+    # asyncio already reaped via proc.wait(); checking via os.kill 0
+    await asyncio.sleep(0.2)
+    with pytest.raises(ProcessLookupError):
+        os.kill(pid, 0)

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -20,6 +20,26 @@ def _make_config(mode: str = "claude_code") -> AgentConfig:
     )
 
 
+def _make_streaming_proc(stdout: bytes) -> MagicMock:
+    """Build a subprocess mock for AgentInvoker's streaming read contract."""
+
+    def _reader(payload: bytes) -> AsyncMock:
+        chunks = iter([payload, b""])
+        reader = AsyncMock()
+        reader.read = AsyncMock(side_effect=lambda _n=4096: next(chunks, b""))
+        return reader
+
+    proc = MagicMock()
+    proc.returncode = 0
+    proc.pid = 12345
+    proc.stdin = MagicMock()
+    proc.stdin.drain = AsyncMock(return_value=None)
+    proc.stdout = _reader(stdout)
+    proc.stderr = _reader(b"")
+    proc.wait = AsyncMock(return_value=0)
+    return proc
+
+
 class TestDeploymentMode:
     """Test that deployment mode constrains allowed tools to Read."""
 
@@ -32,17 +52,16 @@ class TestDeploymentMode:
             "anneal.engine.agent.asyncio.create_subprocess_exec",
             new_callable=AsyncMock,
         ) as mock_exec:
-            mock_proc = AsyncMock()
-            mock_proc.communicate.return_value = (
+            mock_proc = _make_streaming_proc(
                 b'{"result": "output", "total_cost_usd": 0.01, "usage": {"input_tokens": 10, "output_tokens": 5}}',
-                b"",
             )
-            mock_proc.returncode = 0
-            mock_proc.pid = 12345
             mock_exec.return_value = mock_proc
 
             await invoker.invoke_deployment(
-                config, "test prompt", tmp_path, time_budget_seconds=60,
+                config,
+                "test prompt",
+                tmp_path,
+                time_budget_seconds=60,
             )
 
             # Verify the command includes --allowedTools Read
@@ -52,7 +71,9 @@ class TestDeploymentMode:
             assert cmd_list[tools_idx + 1] == "Read"
 
     @pytest.mark.asyncio
-    async def test_deployment_via_invoke_passes_deployment_flag(self, tmp_path: Path) -> None:
+    async def test_deployment_via_invoke_passes_deployment_flag(
+        self, tmp_path: Path
+    ) -> None:
         invoker = AgentInvoker()
         config = _make_config(mode="claude_code")
 
@@ -60,17 +81,16 @@ class TestDeploymentMode:
             "anneal.engine.agent.asyncio.create_subprocess_exec",
             new_callable=AsyncMock,
         ) as mock_exec:
-            mock_proc = AsyncMock()
-            mock_proc.communicate.return_value = (
+            mock_proc = _make_streaming_proc(
                 b'{"result": "", "total_cost_usd": 0.0, "usage": {}}',
-                b"",
             )
-            mock_proc.returncode = 0
-            mock_proc.pid = 12345
             mock_exec.return_value = mock_proc
 
             await invoker.invoke(
-                config, "prompt", tmp_path, time_budget_seconds=60,
+                config,
+                "prompt",
+                tmp_path,
+                time_budget_seconds=60,
                 deployment_mode=True,
             )
 
@@ -88,17 +108,16 @@ class TestDeploymentMode:
             "anneal.engine.agent.asyncio.create_subprocess_exec",
             new_callable=AsyncMock,
         ) as mock_exec:
-            mock_proc = AsyncMock()
-            mock_proc.communicate.return_value = (
+            mock_proc = _make_streaming_proc(
                 b'{"result": "", "total_cost_usd": 0.0, "usage": {}}',
-                b"",
             )
-            mock_proc.returncode = 0
-            mock_proc.pid = 12345
             mock_exec.return_value = mock_proc
 
             await invoker.invoke(
-                config, "prompt", tmp_path, time_budget_seconds=60,
+                config,
+                "prompt",
+                tmp_path,
+                time_budget_seconds=60,
             )
 
             call_args = mock_exec.call_args
@@ -116,18 +135,16 @@ class TestDeploymentMode:
             "anneal.engine.agent.asyncio.create_subprocess_exec",
             new_callable=AsyncMock,
         ) as mock_exec:
-            mock_proc = AsyncMock()
-            mock_proc.communicate.return_value = (
+            mock_exec.side_effect = lambda *args, **kwargs: _make_streaming_proc(
                 b'{"result": "", "total_cost_usd": 0.0, "usage": {}}',
-                b"",
             )
-            mock_proc.returncode = 0
-            mock_proc.pid = 12345
-            mock_exec.return_value = mock_proc
 
             for deployment_mode in [True, False]:
                 await invoker.invoke(
-                    config, "prompt", tmp_path, time_budget_seconds=60,
+                    config,
+                    "prompt",
+                    tmp_path,
+                    time_budget_seconds=60,
                     deployment_mode=deployment_mode,
                 )
                 call_args = mock_exec.call_args

--- a/tests/test_meta_optimization.py
+++ b/tests/test_meta_optimization.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from anneal.engine.agent import AgentInvoker, AgentInvocationError
+from anneal.engine.agent import AgentInvoker
 from anneal.engine.types import AgentConfig
 
 
@@ -18,6 +18,26 @@ def _make_config(mode: str = "claude_code") -> AgentConfig:
         evaluator_model="gpt-4.1-mini",
         max_budget_usd=0.10,
     )
+
+
+def _make_streaming_proc(stdout: bytes) -> MagicMock:
+    """Build a subprocess mock for AgentInvoker's streaming read contract."""
+
+    def _reader(payload: bytes) -> AsyncMock:
+        chunks = iter([payload, b""])
+        reader = AsyncMock()
+        reader.read = AsyncMock(side_effect=lambda _n=4096: next(chunks, b""))
+        return reader
+
+    proc = MagicMock()
+    proc.returncode = 0
+    proc.pid = 12345
+    proc.stdin = MagicMock()
+    proc.stdin.drain = AsyncMock(return_value=None)
+    proc.stdout = _reader(stdout)
+    proc.stderr = _reader(b"")
+    proc.wait = AsyncMock(return_value=0)
+    return proc
 
 
 class TestInvokeMeta:
@@ -35,13 +55,9 @@ class TestInvokeMeta:
             "anneal.engine.agent.asyncio.create_subprocess_exec",
             new_callable=AsyncMock,
         ) as mock_exec:
-            mock_proc = AsyncMock()
-            mock_proc.communicate.return_value = (
+            mock_proc = _make_streaming_proc(
                 b'{"result": "modified", "total_cost_usd": 0.01, "usage": {"input_tokens": 100, "output_tokens": 50}}',
-                b"",
             )
-            mock_proc.returncode = 0
-            mock_proc.pid = 12345
             mock_exec.return_value = mock_proc
 
             await invoker.invoke_meta(
@@ -69,13 +85,9 @@ class TestInvokeMeta:
             "anneal.engine.agent.asyncio.create_subprocess_exec",
             new_callable=AsyncMock,
         ) as mock_exec:
-            mock_proc = AsyncMock()
-            mock_proc.communicate.return_value = (
+            mock_proc = _make_streaming_proc(
                 b'{"result": "", "total_cost_usd": 0.0, "usage": {}}',
-                b"",
             )
-            mock_proc.returncode = 0
-            mock_proc.pid = 12345
             mock_exec.return_value = mock_proc
 
             await invoker.invoke_meta(
@@ -87,8 +99,7 @@ class TestInvokeMeta:
             )
 
             # The prompt sent to stdin should contain the program.md content
-            call_args = mock_proc.communicate.call_args
-            stdin_bytes = call_args[1]["input"] if "input" in call_args[1] else call_args[0][0]
+            stdin_bytes = mock_proc.stdin.write.call_args[0][0]
             stdin_text = stdin_bytes.decode()
             assert "UNIQUE_PROGRAM_CONTENT_XYZ" in stdin_text
 
@@ -104,13 +115,9 @@ class TestInvokeMeta:
             "anneal.engine.agent.asyncio.create_subprocess_exec",
             new_callable=AsyncMock,
         ) as mock_exec:
-            mock_proc = AsyncMock()
-            mock_proc.communicate.return_value = (
+            mock_proc = _make_streaming_proc(
                 b'{"result": "", "total_cost_usd": 0.0, "usage": {}}',
-                b"",
             )
-            mock_proc.returncode = 0
-            mock_proc.pid = 12345
             mock_exec.return_value = mock_proc
 
             await invoker.invoke_meta(
@@ -121,13 +128,14 @@ class TestInvokeMeta:
                 program_md_path=program_md,
             )
 
-            call_args = mock_proc.communicate.call_args
-            stdin_bytes = call_args[1]["input"] if "input" in call_args[1] else call_args[0][0]
+            stdin_bytes = mock_proc.stdin.write.call_args[0][0]
             stdin_text = stdin_bytes.decode()
             assert "SPECIFIC_META_INSTRUCTION" in stdin_text
 
     @pytest.mark.asyncio
-    async def test_meta_prompt_contains_meta_optimization_marker(self, tmp_path: Path) -> None:
+    async def test_meta_prompt_contains_meta_optimization_marker(
+        self, tmp_path: Path
+    ) -> None:
         invoker = AgentInvoker()
         config = _make_config(mode="claude_code")
 
@@ -138,13 +146,9 @@ class TestInvokeMeta:
             "anneal.engine.agent.asyncio.create_subprocess_exec",
             new_callable=AsyncMock,
         ) as mock_exec:
-            mock_proc = AsyncMock()
-            mock_proc.communicate.return_value = (
+            mock_proc = _make_streaming_proc(
                 b'{"result": "", "total_cost_usd": 0.0, "usage": {}}',
-                b"",
             )
-            mock_proc.returncode = 0
-            mock_proc.pid = 12345
             mock_exec.return_value = mock_proc
 
             await invoker.invoke_meta(
@@ -155,15 +159,16 @@ class TestInvokeMeta:
                 program_md_path=program_md,
             )
 
-            call_args = mock_proc.communicate.call_args
-            stdin_bytes = call_args[1]["input"] if "input" in call_args[1] else call_args[0][0]
+            stdin_bytes = mock_proc.stdin.write.call_args[0][0]
             stdin_text = stdin_bytes.decode()
             assert "meta-optimizing" in stdin_text
 
     def test_meta_unknown_mode_raises(self) -> None:
         from pydantic import ValidationError
 
-        with pytest.raises(ValidationError, match="Input should be 'claude_code' or 'api'"):
+        with pytest.raises(
+            ValidationError, match="Input should be 'claude_code' or 'api'"
+        ):
             _make_config(mode="unknown")
 
     @pytest.mark.asyncio
@@ -178,13 +183,9 @@ class TestInvokeMeta:
             "anneal.engine.agent.asyncio.create_subprocess_exec",
             new_callable=AsyncMock,
         ) as mock_exec:
-            mock_proc = AsyncMock()
-            mock_proc.communicate.return_value = (
+            mock_proc = _make_streaming_proc(
                 b'{"result": "", "total_cost_usd": 0.0, "usage": {}}',
-                b"",
             )
-            mock_proc.returncode = 0
-            mock_proc.pid = 12345
             mock_exec.return_value = mock_proc
 
             await invoker.invoke_meta(

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 1
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -143,9 +147,12 @@ ml = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -170,9 +177,12 @@ provides-extras = ["dashboard", "mcp", "ml", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "mypy", specifier = ">=1.13" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=6.0" },
+    { name = "ruff", specifier = ">=0.13" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]
@@ -981,6 +991,66 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/6b/3d5c13fb3e3c4f43206c8f9dfed13778c2ed4f000bacaa0b7ce3c402a265/librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d", size = 184368 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/90/89ddba8e1c20b0922783cd93ed8e64f34dc05ab59c38a9c7e313632e20ff/librt-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b3e3bc363f71bda1639a4ee593cb78f7fbfeacc73411ec0d4c92f00730010a4", size = 68332 },
+    { url = "https://files.pythonhosted.org/packages/a8/40/7aa4da1fb08bdeeb540cb07bfc8207cb32c5c41642f2594dbd0098a0662d/librt-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a09c2f5869649101738653a9b7ab70cf045a1105ac66cbb8f4055e61df78f2d", size = 70581 },
+    { url = "https://files.pythonhosted.org/packages/48/ac/73a2187e1031041e93b7e3a25aae37aa6f13b838c550f7e0f06f66766212/librt-0.9.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ca8e133d799c948db2ab1afc081c333a825b5540475164726dcbf73537e5c2f", size = 203984 },
+    { url = "https://files.pythonhosted.org/packages/5e/3d/23460d571e9cbddb405b017681df04c142fb1b04cbfce77c54b08e28b108/librt-0.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:603138ee838ee1583f1b960b62d5d0007845c5c423feb68e44648b1359014e27", size = 215762 },
+    { url = "https://files.pythonhosted.org/packages/de/1e/42dc7f8ab63e65b20640d058e63e97fd3e482c1edbda3570d813b4d0b927/librt-0.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4003f70c56a5addd6aa0897f200dd59afd3bf7bcd5b3cce46dd21f925743bc2", size = 230288 },
+    { url = "https://files.pythonhosted.org/packages/dc/08/ca812b6d8259ad9ece703397f8ad5c03af5b5fedfce64279693d3ce4087c/librt-0.9.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78042f6facfd98ecb25e9829c7e37cce23363d9d7c83bc5f72702c5059eb082b", size = 224103 },
+    { url = "https://files.pythonhosted.org/packages/b6/3f/620490fb2fa66ffd44e7f900254bc110ebec8dac6c1b7514d64662570e6f/librt-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a361c9434a64d70a7dbb771d1de302c0cc9f13c0bffe1cf7e642152814b35265", size = 232122 },
+    { url = "https://files.pythonhosted.org/packages/e9/83/12864700a1b6a8be458cf5d05db209b0d8e94ae281e7ec261dbe616597b4/librt-0.9.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:dd2c7e082b0b92e1baa4da28163a808672485617bc855cc22a2fd06978fa9084", size = 225045 },
+    { url = "https://files.pythonhosted.org/packages/fd/1b/845d339c29dc7dbc87a2e992a1ba8d28d25d0e0372f9a0a2ecebde298186/librt-0.9.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7e6274fd33fc5b2a14d41c9119629d3ff395849d8bcbc80cf637d9e8d2034da8", size = 227372 },
+    { url = "https://files.pythonhosted.org/packages/8d/fe/277985610269d926a64c606f761d58d3db67b956dbbf40024921e95e7fcb/librt-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5093043afb226ecfa1400120d1ebd4442b4f99977783e4f4f7248879009b227f", size = 248224 },
+    { url = "https://files.pythonhosted.org/packages/92/1b/ee486d244b8de6b8b5dbaefabe6bfdd4a72e08f6353edf7d16d27114da8d/librt-0.9.0-cp312-cp312-win32.whl", hash = "sha256:9edcc35d1cae9fd5320171b1a838c7da8a5c968af31e82ecc3dff30b4be0957f", size = 55986 },
+    { url = "https://files.pythonhosted.org/packages/89/7a/ba1737012308c17dc6d5516143b5dce9a2c7ba3474afd54e11f44a4d1ef3/librt-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc2917258e131ae5f958a4d872e07555b51cb7466a43433218061c74ef33745", size = 63260 },
+    { url = "https://files.pythonhosted.org/packages/36/e4/01752c113da15127f18f7bf11142f5640038f062407a611c059d0036c6aa/librt-0.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:90e6d5420fc8a300518d4d2288154ff45005e920425c22cbbfe8330f3f754bd9", size = 53694 },
+    { url = "https://files.pythonhosted.org/packages/5f/d7/1b3e26fffde1452d82f5666164858a81c26ebe808e7ae8c9c88628981540/librt-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f29b68cd9714531672db62cc54f6e8ff981900f824d13fa0e00749189e13778e", size = 68367 },
+    { url = "https://files.pythonhosted.org/packages/a5/5b/c61b043ad2e091fbe1f2d35d14795e545d0b56b03edaa390fa1dcee3d160/librt-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d5c8a5929ac325729f6119802070b561f4db793dffc45e9ac750992a4ed4d22", size = 70595 },
+    { url = "https://files.pythonhosted.org/packages/a3/22/2448471196d8a73370aa2f23445455dc42712c21404081fcd7a03b9e0749/librt-0.9.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:756775d25ec8345b837ab52effee3ad2f3b2dfd6bbee3e3f029c517bd5d8f05a", size = 204354 },
+    { url = "https://files.pythonhosted.org/packages/ac/5e/39fc4b153c78cfd2c8a2dcb32700f2d41d2312aa1050513183be4540930d/librt-0.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8f5d00b49818f4e2b1667db994488b045835e0ac16fe2f924f3871bd2b8ac5", size = 216238 },
+    { url = "https://files.pythonhosted.org/packages/d7/42/bc2d02d0fa7badfa63aa8d6dcd8793a9f7ef5a94396801684a51ed8d8287/librt-0.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c81aef782380f0f13ead670aae01825eb653b44b046aa0e5ebbb79f76ed4aa11", size = 230589 },
+    { url = "https://files.pythonhosted.org/packages/c8/7b/e2d95cc513866373692aa5edf98080d5602dd07cabfb9e5d2f70df2f25f7/librt-0.9.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66b58fed90a545328e80d575467244de3741e088c1af928f0b489ebec3ef3858", size = 224610 },
+    { url = "https://files.pythonhosted.org/packages/31/d5/6cec4607e998eaba57564d06a1295c21b0a0c8de76e4e74d699e627bd98c/librt-0.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e78fb7419e07d98c2af4b8567b72b3eaf8cb05caad642e9963465569c8b2d87e", size = 232558 },
+    { url = "https://files.pythonhosted.org/packages/95/8c/27f1d8d3aaf079d3eb26439bf0b32f1482340c3552e324f7db9dca858671/librt-0.9.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c3786f0f4490a5cd87f1ed6cefae833ad6b1060d52044ce0434a2e85893afd0", size = 225521 },
+    { url = "https://files.pythonhosted.org/packages/6b/d8/1e0d43b1c329b416017619469b3c3801a25a6a4ef4a1c68332aeaa6f72ca/librt-0.9.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8494cfc61e03542f2d381e71804990b3931175a29b9278fdb4a5459948778dc2", size = 227789 },
+    { url = "https://files.pythonhosted.org/packages/2c/b4/d3d842e88610fcd4c8eec7067b0c23ef2d7d3bff31496eded6a83b0f99be/librt-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07cf11f769831186eeac424376e6189f20ace4f7263e2134bdb9757340d84d4d", size = 248616 },
+    { url = "https://files.pythonhosted.org/packages/ec/28/527df8ad0d1eb6c8bdfa82fc190f1f7c4cca5a1b6d7b36aeabf95b52d74d/librt-0.9.0-cp313-cp313-win32.whl", hash = "sha256:850d6d03177e52700af605fd60db7f37dcb89782049a149674d1a9649c2138fd", size = 56039 },
+    { url = "https://files.pythonhosted.org/packages/f3/a7/413652ad0d92273ee5e30c000fc494b361171177c83e57c060ecd3c21538/librt-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a5af136bfba820d592f86c67affcef9b3ff4d4360ac3255e341e964489b48519", size = 63264 },
+    { url = "https://files.pythonhosted.org/packages/a4/0a/92c244309b774e290ddb15e93363846ae7aa753d9586b8aad511c5e6145b/librt-0.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:4c4d0440a3a8e31d962340c3e1cc3fc9ee7febd34c8d8f770d06adb947779ea5", size = 53728 },
+    { url = "https://files.pythonhosted.org/packages/cd/c1/184e539543f06ea2912f4b92a5ffaede4f9b392689e3f00acbf8134bee92/librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb", size = 67830 },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/23399bdcb7afca819acacdef31b37ee59de261bd66b503a7995c03c4b0dc/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499", size = 70280 },
+    { url = "https://files.pythonhosted.org/packages/9f/0b/4542dc5a2b8772dbf92cafb9194701230157e73c14b017b6961a23598b03/librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f", size = 201925 },
+    { url = "https://files.pythonhosted.org/packages/31/d4/8ee7358b08fd0cfce051ef96695380f09b3c2c11b77c9bfbc367c921cce5/librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1", size = 212381 },
+    { url = "https://files.pythonhosted.org/packages/f2/94/a2025fe442abedf8b038038dab3dba942009ad42b38ea064a1a9e6094241/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f", size = 227065 },
+    { url = "https://files.pythonhosted.org/packages/7c/e9/b9fcf6afa909f957cfbbf918802f9dada1bd5d3c1da43d722fd6a310dc3f/librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a", size = 221333 },
+    { url = "https://files.pythonhosted.org/packages/ac/7c/ba54cd6aa6a3c8cd12757a6870e0c79a64b1e6327f5248dcff98423f4d43/librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f", size = 229051 },
+    { url = "https://files.pythonhosted.org/packages/4b/4b/8cfdbad314c8677a0148bf0b70591d6d18587f9884d930276098a235461b/librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845", size = 222492 },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/2eda69563a1a88706808decdce035e4b32755dbfbb0d05e1a65db9547ed1/librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b", size = 223849 },
+    { url = "https://files.pythonhosted.org/packages/04/44/b2ed37df6be5b3d42cfe36318e0598e80843d5c6308dd63d0bf4e0ce5028/librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b", size = 245001 },
+    { url = "https://files.pythonhosted.org/packages/47/e7/617e412426df89169dd2a9ed0cc8752d5763336252c65dbf945199915119/librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9", size = 51799 },
+    { url = "https://files.pythonhosted.org/packages/24/ed/c22ca4db0ca3cbc285e4d9206108746beda561a9792289c3c31281d7e9df/librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e", size = 59165 },
+    { url = "https://files.pythonhosted.org/packages/24/56/875398fafa4cbc8f15b89366fc3287304ddd3314d861f182a4b87595ace0/librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f", size = 49292 },
+    { url = "https://files.pythonhosted.org/packages/4c/61/bc448ecbf9b2d69c5cff88fe41496b19ab2a1cbda0065e47d4d0d51c0867/librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4", size = 70175 },
+    { url = "https://files.pythonhosted.org/packages/60/f2/c47bb71069a73e2f04e70acbd196c1e5cc411578ac99039a224b98920fd4/librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228", size = 72951 },
+    { url = "https://files.pythonhosted.org/packages/29/19/0549df59060631732df758e8886d92088da5fdbedb35b80e4643664e8412/librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54", size = 225864 },
+    { url = "https://files.pythonhosted.org/packages/9d/f8/3b144396d302ac08e50f89e64452c38db84bc7b23f6c60479c5d3abd303c/librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71", size = 241155 },
+    { url = "https://files.pythonhosted.org/packages/7a/ce/ee67ec14581de4043e61d05786d2aed6c9b5338816b7859bcf07455c6a9f/librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938", size = 252235 },
+    { url = "https://files.pythonhosted.org/packages/8a/fa/0ead15daa2b293a54101550b08d4bafe387b7d4a9fc6d2b985602bae69b6/librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3", size = 244963 },
+    { url = "https://files.pythonhosted.org/packages/29/68/9fbf9a9aa704ba87689e40017e720aced8d9a4d2b46b82451d8142f91ec9/librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283", size = 257364 },
+    { url = "https://files.pythonhosted.org/packages/1a/8d/9d60869f1b6716c762e45f66ed945b1e5dd649f7377684c3b176ae424648/librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee", size = 247661 },
+    { url = "https://files.pythonhosted.org/packages/70/ff/a5c365093962310bfdb4f6af256f191085078ffb529b3f0cbebb5b33ebe2/librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c", size = 248238 },
+    { url = "https://files.pythonhosted.org/packages/a0/3c/2d34365177f412c9e19c0a29f969d70f5343f27634b76b765a54d8b27705/librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15", size = 269457 },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453 },
+    { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044 },
+    { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009 },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1180,6 +1250,58 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.20.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/4e/7560e4528db9e9b147e4c0f22660466bf30a0a1fe3d63d1b9d3b0fd354ee/mypy-1.20.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4dbfcf869f6b0517f70cf0030ba6ea1d6645e132337a7d5204a18d8d5636c02b", size = 14539393 },
+    { url = "https://files.pythonhosted.org/packages/32/d9/34a5efed8124f5a9234f55ac6a4ced4201e2c5b81e1109c49ad23190ec8c/mypy-1.20.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b6481b228d072315b053210b01ac320e1be243dc17f9e5887ef167f23f5fae4", size = 13361642 },
+    { url = "https://files.pythonhosted.org/packages/d1/14/eb377acf78c03c92d566a1510cda8137348215b5335085ef662ab82ecd3a/mypy-1.20.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34397cdced6b90b836e38182076049fdb41424322e0b0728c946b0939ebdf9f6", size = 13740347 },
+    { url = "https://files.pythonhosted.org/packages/b9/94/7e4634a32b641aa1c112422eed1bbece61ee16205f674190e8b536f884de/mypy-1.20.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5da6976f20cae27059ea8d0c86e7cef3de720e04c4bb9ee18e3690fdb792066", size = 14734042 },
+    { url = "https://files.pythonhosted.org/packages/7a/f3/f7e62395cb7f434541b4491a01149a4439e28ace4c0c632bbf5431e92d1f/mypy-1.20.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56908d7e08318d39f85b1f0c6cfd47b0cac1a130da677630dac0de3e0623e102", size = 14964958 },
+    { url = "https://files.pythonhosted.org/packages/3e/0d/47e3c3a0ec2a876e35aeac365df3cac7776c36bbd4ed18cc521e1b9d255b/mypy-1.20.2-cp312-cp312-win_amd64.whl", hash = "sha256:d52ad8d78522da1d308789df651ee5379088e77c76cb1994858d40a426b343b9", size = 10911340 },
+    { url = "https://files.pythonhosted.org/packages/d6/b2/6c852d72e0ea8b01f49da817fb52539993cde327e7d010e0103dc12d0dac/mypy-1.20.2-cp312-cp312-win_arm64.whl", hash = "sha256:785b08db19c9f214dc37d65f7c165d19a30fcecb48abfa30f31b01b5acaabb58", size = 9833947 },
+    { url = "https://files.pythonhosted.org/packages/5b/c4/b93812d3a192c9bcf5df405bd2f30277cd0e48106a14d1023c7f6ed6e39b/mypy-1.20.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:edfbfca868cdd6bd8d974a60f8a3682f5565d3f5c99b327640cedd24c4264026", size = 14524670 },
+    { url = "https://files.pythonhosted.org/packages/f3/47/42c122501bff18eaf1e8f457f5c017933452d8acdc52918a9f59f6812955/mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943", size = 13336218 },
+    { url = "https://files.pythonhosted.org/packages/92/8f/75bbc92f41725fbd585fb17b440b1119b576105df1013622983e18640a93/mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517", size = 13724906 },
+    { url = "https://files.pythonhosted.org/packages/a1/32/4c49da27a606167391ff0c39aa955707a00edc500572e562f7c36c08a71f/mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15", size = 14726046 },
+    { url = "https://files.pythonhosted.org/packages/7f/fc/4e354a1bd70216359deb0c9c54847ee6b32ef78dfb09f5131ff99b494078/mypy-1.20.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d56a78b646f2e3daa865bc70cd5ec5a46c50045801ca8ff17a0c43abc97e3ee", size = 14955587 },
+    { url = "https://files.pythonhosted.org/packages/62/b2/c0f2056e9eb8f08c62cafd9715e4584b89132bdc832fcf85d27d07b5f3e5/mypy-1.20.2-cp313-cp313-win_amd64.whl", hash = "sha256:2a4102b03bb7481d9a91a6da8d174740c9c8c4401024684b9ca3b7cc5e49852f", size = 10922681 },
+    { url = "https://files.pythonhosted.org/packages/e5/14/065e333721f05de8ef683d0aa804c23026bcc287446b61cac657b902ccac/mypy-1.20.2-cp313-cp313-win_arm64.whl", hash = "sha256:a95a9248b0c6fd933a442c03c3b113c3b61320086b88e2c444676d3fd1ca3330", size = 9830560 },
+    { url = "https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30", size = 14524561 },
+    { url = "https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924", size = 13363883 },
+    { url = "https://files.pythonhosted.org/packages/2a/56/983916806bf4eddeaaa2c9230903c3669c6718552a921154e1c5182c701f/mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb", size = 13742945 },
+    { url = "https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc", size = 14706163 },
+    { url = "https://files.pythonhosted.org/packages/94/97/48ff3b297cafcc94d185243a9190836fb1b01c1b0918fff64e941e973cc9/mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558", size = 14938677 },
+    { url = "https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8", size = 11089322 },
+    { url = "https://files.pythonhosted.org/packages/78/c2/ce7ee2ba36aeb954ba50f18fa25d9c1188578654b97d02a66a15b6f09531/mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3", size = 10017775 },
+    { url = "https://files.pythonhosted.org/packages/4e/a1/9d93a7d0b5859af0ead82b4888b46df6c8797e1bc5e1e262a08518c6d48e/mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609", size = 15549002 },
+    { url = "https://files.pythonhosted.org/packages/00/d2/09a6a10ee1bf0008f6c144d9676f2ca6a12512151b4e0ad0ff6c4fac5337/mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2", size = 14401942 },
+    { url = "https://files.pythonhosted.org/packages/57/da/9594b75c3c019e805250bed3583bdf4443ff9e6ef08f97e39ae308cb06f2/mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c", size = 15041649 },
+    { url = "https://files.pythonhosted.org/packages/97/77/f75a65c278e6e8eba2071f7f5a90481891053ecc39878cc444634d892abe/mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744", size = 15864588 },
+    { url = "https://files.pythonhosted.org/packages/d7/46/1a4e1c66e96c1a3246ddf5403d122ac9b0a8d2b7e65730b9d6533ba7a6d3/mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6", size = 16093956 },
+    { url = "https://files.pythonhosted.org/packages/5a/2c/78a8851264dec38cd736ca5b8bc9380674df0dd0be7792f538916157716c/mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec", size = 12568661 },
+    { url = "https://files.pythonhosted.org/packages/83/01/cd7318aa03493322ce275a0e14f4f52b8896335e4e79d4fb8153a7ad2b77/mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382", size = 10389240 },
+    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314 },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963 },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1266,6 +1388,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366 },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328 },
 ]
 
 [[package]]
@@ -1918,6 +2049,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713 },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267 },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182 },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012 },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479 },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040 },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377 },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784 },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088 },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770 },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355 },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758 },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498 },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765 },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277 },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758 },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821 },
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2141,6 +2297,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374 },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements the Symphony-inspired runtime hardening work from `.docs/impl/enhancement-symphony-runtime-hardening.md` and clears the strict typing/lint debt needed to make the new runtime paths verifiable.

This PR contains two logical commits:

- `feat(agent): harden runtime stalls and retries`
- `chore(types): clear strict typing baseline`

## Runtime Hardening

### Activity-heartbeat stall detection

Replaces the Claude Code subprocess `communicate()` path with streamed stdout/stderr readers plus a watchdog. The watchdog tracks the last observed subprocess output and kills the process group when silence exceeds `AgentConfig.stall_timeout_seconds`.

Key properties:

- wall-clock `time_budget_seconds` remains the hard backstop
- `stall_timeout_seconds=0` disables stall detection
- stalls raise `AgentStalledError`, which subclasses `AgentTimeoutError`
- existing runner timeout handling still routes stalled runs through the `Outcome.KILLED` path
- subprocess output bytes are still collected and parsed after normal completion

### Transient vs structural failure classification

Splits agent invocation failures into retryable and terminal categories:

- `AgentTransientError`: rate limits, 5xx responses, partial JSON, network/OS IO failures, known transient Claude stderr signatures
- `AgentStructuralError`: auth/schema/unknown failures and Claude `is_error` or `error_*` payloads

The runner now wraps mutation-agent invocation with an in-experiment retry loop:

- bounded by `AgentConfig.max_transient_retries`
- exponential backoff via `transient_retry_base_seconds`
- capped by `transient_retry_cap_seconds`
- retries do not consume a new experiment slot
- exhausted transient retries are promoted to `AgentStructuralError`, preserving the existing `Outcome.CRASHED` record shape
- wall-clock and stall timeouts still propagate through the timeout path without retry wrapping

## Configuration

Adds these `AgentConfig` fields:

- `stall_timeout_seconds: int = 300`
- `max_transient_retries: int = 3`
- `transient_retry_base_seconds: float = 10.0`
- `transient_retry_cap_seconds: float = 300.0`

## Tests

Adds focused coverage for:

- silent subprocesses being killed at the stall window
- heartbeat subprocesses completing without false-positive stalls
- wall-clock timeout remaining authoritative under steady output
- disabled stall watchdog behavior
- stdin prompt delivery under streamed IO
- process-group kill behavior
- transient/structural API exception classification
- transient/structural Claude subprocess stderr classification
- runner retry behavior, retry exhaustion, no retry for structural failures, and deployment invocation routing

Updates existing subprocess-mocking tests to match the streamed IO contract in:

- `tests/test_agent_coverage.py`
- `tests/test_deployment.py`
- `tests/test_meta_optimization.py`

## Type And Lint Cleanup

Clears the strict typing baseline across the package so the new runtime paths can be checked under `mypy --strict`.

Highlights:

- adds dev dependencies for `mypy`, `ruff`, and `types-PyYAML`
- adds scoped `ignore_missing_imports` overrides for optional or stub-less dependencies
- fixes `Literal` narrowing for agent hypothesis source
- fixes optional narrowing, JSON-deserialization narrowing, and protocol signature drift
- replaces platform-specific `FileLock` annotations with `BaseFileLock`
- removes unused ignores/imports and ruff violations
- formats touched files with `ruff format`

## Validation

Passed locally:

```bash
uv run ruff check anneal/ tests/test_deployment.py tests/test_meta_optimization.py tests/test_agent_coverage.py tests/test_agent_retry_classification.py tests/test_agent_stall_detection.py
uv run ruff format --check anneal/cli.py anneal/engine/agent.py anneal/engine/archive.py anneal/engine/bayesian.py anneal/engine/context.py anneal/engine/dashboard.py anneal/engine/knowledge.py anneal/engine/learning_pool.py anneal/engine/notifications.py anneal/engine/runner.py anneal/engine/scheduler.py anneal/engine/search.py anneal/engine/strategy.py anneal/engine/tree_search.py anneal/engine/types.py anneal/eval_protocol.py anneal/mcp_server.py tests/test_agent_coverage.py tests/test_agent_retry_classification.py tests/test_agent_stall_detection.py tests/test_deployment.py tests/test_meta_optimization.py
uv run mypy --strict anneal/
uv run pytest tests/test_agent_stall_detection.py tests/test_agent_retry_classification.py tests/test_agent_coverage.py tests/test_deployment.py tests/test_meta_optimization.py -q
uv run pytest -q
```

Full suite result:

```text
868 passed, 7 skipped
```

Known baseline issue:

- `uv run ruff format --check .` still reports untouched files that predate this branch and need a separate repository-wide formatting pass.
